### PR TITLE
feat: 添加招聘类型变体规范 (experienced/campus/internship)

### DIFF
--- a/backend/openresume_api/adapters/official.py
+++ b/backend/openresume_api/adapters/official.py
@@ -4,7 +4,7 @@ import webbrowser
 
 from sqlmodel import Session
 
-from ..career_collectors import career_collector_runner, load_sources
+from ..career_collectors import career_collector_runner, filter_sources, load_sources
 from ..config import settings
 from ..models import CandidateProfile, JobListing
 from ..schemas import PlatformCapabilityResponse, SearchSessionCreate
@@ -76,8 +76,15 @@ class OfficialAdapter:
         search: SearchSessionCreate,
         profile: CandidateProfile,
     ) -> list[NormalizedJobDraft]:
-        sources = list(load_sources())
-        run_results = await career_collector_runner.run(sources, search, profile)
+        all_sources = load_sources()
+        sources = filter_sources(
+            all_sources,
+            variants=search.source_variants or None,
+            companies=search.source_companies or None,
+        )
+        if not sources:
+            raise PlatformDataError("请至少选择一个招聘类型或公司。")
+        run_results = await career_collector_runner.run(list(sources), search, profile)
 
         stats = {
             "sources_declared": len(sources),

--- a/backend/openresume_api/career_collectors/__init__.py
+++ b/backend/openresume_api/career_collectors/__init__.py
@@ -1,4 +1,10 @@
-from .manifest import load_sources
+from .manifest import filter_sources, get_available_companies, get_available_variants, load_sources
 from .runner import career_collector_runner
 
-__all__ = ["career_collector_runner", "load_sources"]
+__all__ = [
+    "career_collector_runner",
+    "load_sources",
+    "get_available_variants",
+    "get_available_companies",
+    "filter_sources",
+]

--- a/backend/openresume_api/career_collectors/companies/bytedance.py
+++ b/backend/openresume_api/career_collectors/companies/bytedance.py
@@ -94,9 +94,11 @@ class BytedanceCollector(CompanyCollector):
             or _first_nested_name(payload.get("job_subject"))
             or _first_nested_name(payload.get("department_info"))
         )
-        employment_type = (
-            "\u793e\u62db" if source.variant == "experienced" else "\u6821\u62db"
-        )
+        employment_type = {
+            "experienced": "\u793e\u62db",
+            "campus": "\u6821\u62db",
+            "internship": "\u5b9e\u4e60",
+        }.get(source.variant, "")
         if not employment_type:
             employment_type = normalize_whitespace(
                 _first_nested_name(payload.get("recruit_type"))

--- a/backend/openresume_api/career_collectors/manifest.py
+++ b/backend/openresume_api/career_collectors/manifest.py
@@ -22,8 +22,40 @@ SOURCES: tuple[CareerSiteSource, ...] = (
         variant="campus",
         label="\u5b57\u8282\u8df3\u52a8\u6821\u62db",
     ),
+    CareerSiteSource(
+        key="bytedance-internship",
+        company_name="\u5b57\u8282\u8df3\u52a8",
+        entry_url="https://jobs.bytedance.com/campus",
+        source_site="jobs.bytedance.com",
+        collector_key="bytedance",
+        variant="internship",
+        label="\u5b57\u8282\u8df3\u52a8\u5b9e\u4e60",
+    ),
 )
 
 
 def load_sources() -> tuple[CareerSiteSource, ...]:
     return SOURCES
+
+
+def get_available_variants() -> list[str]:
+    return list(dict.fromkeys(source.variant for source in SOURCES))
+
+
+def get_available_companies() -> list[str]:
+    return list(dict.fromkeys(source.company_name for source in SOURCES))
+
+
+def filter_sources(
+    sources: tuple[CareerSiteSource, ...],
+    variants: list[str] | None = None,
+    companies: list[str] | None = None,
+) -> tuple[CareerSiteSource, ...]:
+    if not variants and not companies:
+        return sources
+    filtered = list(sources)
+    if variants:
+        filtered = [s for s in filtered if s.variant in variants]
+    if companies:
+        filtered = [s for s in filtered if s.company_name in companies]
+    return tuple(filtered)

--- a/backend/openresume_api/career_collectors/providers/bytedance_atsx.py
+++ b/backend/openresume_api/career_collectors/providers/bytedance_atsx.py
@@ -69,6 +69,17 @@ VARIANT_CONFIGS = {
             HeaderProfile("office", "society", "office"),
         ),
     ),
+    "internship": BytedanceVariantConfig(
+        variant="internship",
+        entry_url="https://jobs.bytedance.com/campus",
+        search_path="/campus/position/list",
+        detail_path_template="https://jobs.bytedance.com/campus/position/{job_id}/detail",
+        portal_type=3,
+        header_profiles=(
+            HeaderProfile("campus", "campus", "campus"),
+            HeaderProfile("office", "society", "office"),
+        ),
+    ),
 }
 
 

--- a/backend/openresume_api/main.py
+++ b/backend/openresume_api/main.py
@@ -43,6 +43,7 @@ from .services.profile import profile_service
 from .services.risk import risk_control_service
 from .services.runtime_config import runtime_config_service
 from .services.search import search_service
+from .career_collectors import get_available_companies, get_available_variants, load_sources
 
 SessionDep = Annotated[Session, Depends(get_session)]
 
@@ -208,7 +209,7 @@ def runtime_config_response() -> RuntimeConfigResponse:
         ),
         openai_base_url=llm_config.openai_base_url,
         openai_model=llm_config.openai_model,
-        official_sources_summary="代码清单：字节跳动社招 + 校招",
+        official_sources_summary="代码清单：字节跳动社招 + 校招 + 实习",
     )
 
 
@@ -339,6 +340,30 @@ def list_platforms():
     return platform_gateway.list_capabilities()
 
 
+@app.get("/api/sources")
+def list_sources():
+    sources = load_sources()
+    return [
+        {
+            "key": source.key,
+            "company_name": source.company_name,
+            "variant": source.variant,
+            "label": source.label,
+        }
+        for source in sources
+    ]
+
+
+@app.get("/api/sources/variants")
+def list_source_variants():
+    return get_available_variants()
+
+
+@app.get("/api/sources/companies")
+def list_source_companies():
+    return get_available_companies()
+
+
 @app.get("/api/platforms/{platform}/capabilities")
 def get_platform_capabilities(platform: str):
     return platform_gateway.get(platform).capability()
@@ -384,7 +409,7 @@ def get_risk_status(platform: str, db: SessionDep):
 async def create_search_session(payload: SearchSessionCreate, db: SessionDep):
     platforms = list(dict.fromkeys(payload.platforms))
     if not platforms:
-        raise HTTPException(status_code=400, detail="请至少选择一个平台。")
+        platforms = ["official"]
 
     adapters = platform_gateway.resolve(platforms)
     for adapter in adapters:
@@ -417,6 +442,8 @@ async def create_search_session(payload: SearchSessionCreate, db: SessionDep):
         cities=payload.cities,
         salary_floor=payload.salary_floor,
         must_have_keywords=payload.must_have_keywords,
+        source_variants=payload.source_variants,
+        source_companies=payload.source_companies,
     )
     return await search_service.create_session(db, normalized_payload)
 

--- a/backend/openresume_api/schemas.py
+++ b/backend/openresume_api/schemas.py
@@ -59,6 +59,8 @@ class SearchSessionCreate(BaseModel):
     cities: list[str]
     salary_floor: int = 0
     must_have_keywords: list[str] = Field(default_factory=list)
+    source_variants: list[str] = Field(default_factory=list)
+    source_companies: list[str] = Field(default_factory=list)
 
 
 class SearchEventPayload(BaseModel):

--- a/backend/tests/test_bytedance_atsx.py
+++ b/backend/tests/test_bytedance_atsx.py
@@ -1,0 +1,316 @@
+import json
+import subprocess
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from openresume_api.career_collectors.providers.bytedance_atsx import (
+    BytedanceAtsxClient,
+    BytedanceVariantConfig,
+    HeaderProfile,
+    SignedSession,
+    VARIANT_CONFIGS,
+)
+
+
+class TestHeaderProfile:
+    def test_header_profile_is_frozen_dataclass(self):
+        profile = HeaderProfile(
+            portal_channel="campus",
+            website_path="campus",
+            cookie_channel="campus",
+        )
+        assert profile.portal_channel == "campus"
+        assert profile.website_path == "campus"
+        assert profile.cookie_channel == "campus"
+
+    def test_header_profile_is_immutable(self):
+        profile = HeaderProfile(
+            portal_channel="office",
+            website_path="society",
+            cookie_channel="office",
+        )
+        with pytest.raises(AttributeError):
+            profile.portal_channel = "campus"
+
+
+class TestBytedanceVariantConfig:
+    def test_search_page_url_encodes_keyword(self):
+        config = BytedanceVariantConfig(
+            variant="test",
+            entry_url="https://example.com/",
+            search_path="/search",
+            detail_path_template="https://example.com/job/{job_id}",
+            portal_type=1,
+            header_profiles=(),
+        )
+        url = config.search_page_url("前端工程师", current=1, limit=10)
+        assert "keywords=%E5%89%8D%E7%AB%AF%E5%B7%A5%E7%A8%8B%E5%B8%88" in url
+        assert "current=1" in url
+        assert "limit=10" in url
+
+    def test_detail_url_formats_job_id(self):
+        config = BytedanceVariantConfig(
+            variant="test",
+            entry_url="https://example.com/",
+            search_path="/search",
+            detail_path_template="https://example.com/job/{job_id}/detail",
+            portal_type=1,
+            header_profiles=(),
+        )
+        url = config.detail_url("12345")
+        assert url == "https://example.com/job/12345/detail"
+
+
+class TestVariantConfigs:
+    def test_experienced_config_exists(self):
+        assert "experienced" in VARIANT_CONFIGS
+        config = VARIANT_CONFIGS["experienced"]
+        assert config.portal_type == 2
+        assert config.entry_url == "https://jobs.bytedance.com/"
+        assert "/experienced/" in config.search_path
+
+    def test_campus_config_exists(self):
+        assert "campus" in VARIANT_CONFIGS
+        config = VARIANT_CONFIGS["campus"]
+        assert config.portal_type == 3
+        assert config.entry_url == "https://jobs.bytedance.com/campus"
+        assert "/campus/" in config.search_path
+
+    def test_both_configs_have_header_profiles(self):
+        for variant, config in VARIANT_CONFIGS.items():
+            assert len(config.header_profiles) >= 1, f"{variant} missing header profiles"
+
+
+class TestSignedSession:
+    def test_signed_session_defaults_csrf_token_to_none(self):
+        session = SignedSession(
+            header_profile=HeaderProfile("a", "b", "c"),
+            cookie_values={"key": "value"},
+        )
+        assert session.csrf_token is None
+
+    def test_signed_session_can_set_csrf_token(self):
+        session = SignedSession(
+            header_profile=HeaderProfile("a", "b", "c"),
+            cookie_values={},
+            csrf_token="test-token",
+        )
+        assert session.csrf_token == "test-token"
+
+
+class TestBytedanceAtsxClient:
+    @pytest.fixture
+    def client(self):
+        return BytedanceAtsxClient(
+            timeout_seconds=10.0,
+            user_agent="TestAgent/1.0",
+            max_pages=2,
+            page_size=10,
+        )
+
+    def test_detail_url_returns_correct_format(self, client):
+        url = client.detail_url(variant="experienced", job_id="12345")
+        assert url == "https://jobs.bytedance.com/experienced/position/12345/detail"
+
+        url = client.detail_url(variant="campus", job_id="67890")
+        assert url == "https://jobs.bytedance.com/campus/position/67890/detail"
+
+    def test_search_payload_structure(self, client):
+        payload = client._search_payload(
+            "前端工程师",
+            current=2,
+            limit=20,
+            portal_type=3,
+        )
+        assert payload["keyword"] == "前端工程师"
+        assert payload["limit"] == 20
+        assert payload["offset"] == 20
+        assert payload["portal_type"] == 3
+        assert payload["portal_entrance"] == 1
+        assert payload["job_category_id_list"] == []
+        assert payload["location_code_list"] == []
+
+    def test_new_cookie_values_structure(self, client):
+        cookies = client._new_cookie_values("campus")
+        assert cookies["channel"] == "campus"
+        assert cookies["platform"] == "pc"
+        assert "s_v_web_id" in cookies
+        assert "device-id" in cookies
+        assert len(cookies["s_v_web_id"].split("_")) == 2
+
+    def test_new_cookie_values_generates_random_values(self, client):
+        cookies1 = client._new_cookie_values("office")
+        cookies2 = client._new_cookie_values("office")
+        assert cookies1["s_v_web_id"] != cookies2["s_v_web_id"]
+        assert cookies1["device-id"] != cookies2["device-id"]
+
+    def test_cookie_header_format(self, client):
+        header = client._cookie_header({
+            "key1": "value1",
+            "key2": "value2",
+            "empty": "",
+        })
+        assert header == "key1=value1; key2=value2"
+        assert "empty" not in header
+
+    def test_cookie_from_header_extracts_first_cookie(self, client):
+        key, value = client._cookie_from_header("session=abc123; Path=/; HttpOnly")
+        assert key == "session"
+        assert value == "abc123"
+
+    def test_cookie_from_header_handles_invalid_input(self, client):
+        key, value = client._cookie_from_header("")
+        assert key == ""
+        assert value == ""
+
+        key, value = client._cookie_from_header("no-equals-sign")
+        assert key == ""
+        assert value == ""
+
+    def test_query_string_encoding(self, client):
+        qs = client._query_string({
+            "keyword": "前端",
+            "portal_type": 3,
+            "empty_list": [],
+        })
+        assert "keyword=%E5%89%8D%E7%AB%AF" in qs
+        assert "portal_type=3" in qs
+
+    def test_query_string_skips_none_values(self, client):
+        qs = client._query_string({
+            "present": "value",
+            "absent": None,
+        })
+        assert "present=value" in qs
+        assert "absent" not in qs
+
+    def test_stringify_query_value_handles_bool(self, client):
+        assert client._stringify_query_value(True) == "true"
+        assert client._stringify_query_value(False) == "false"
+
+    def test_stringify_query_value_handles_list(self, client):
+        result = client._stringify_query_value([1, 2, 3])
+        assert result == "1,2,3"
+
+    def test_stringify_query_value_handles_string(self, client):
+        assert client._stringify_query_value("test") == "test"
+
+    def test_api_headers_structure(self, client):
+        session = SignedSession(
+            header_profile=HeaderProfile("campus", "campus", "campus"),
+            cookie_values={"channel": "campus"},
+            csrf_token="test-csrf",
+        )
+        headers = client._api_headers(
+            referer_url="https://example.com/search",
+            session=session,
+            include_content_type=True,
+        )
+        assert headers["Portal-Channel"] == "campus"
+        assert headers["Portal-Platform"] == "pc"
+        assert headers["website-path"] == "campus"
+        assert headers["x-csrf-token"] == "test-csrf"
+        assert headers["content-type"] == "application/json"
+        assert "channel=campus" in headers["cookie"]
+
+    def test_api_headers_without_content_type(self, client):
+        session = SignedSession(
+            header_profile=HeaderProfile("office", "society", "office"),
+            cookie_values={},
+        )
+        headers = client._api_headers(
+            referer_url="https://example.com/search",
+            session=session,
+            include_content_type=False,
+        )
+        assert "content-type" not in headers
+
+    def test_extract_module_function_finds_target(self, client):
+        script = """
+        var modules = {
+            57195:function(e,t,n){
+                "use strict";
+                n.r(t);
+                var r = function(url) { return "signed:" + url; };
+                t.sign = r;
+            },
+            12345:function(e,t,n){
+                "use strict";
+                n.r(t);
+            }
+        };
+        """
+        result = client._extract_module_function(script, 57195)
+        assert "function(e,t,n)" in result
+        assert "t.sign" in result
+
+    def test_extract_module_function_returns_empty_for_missing(self, client):
+        script = "var modules = { 12345: function() {} };"
+        result = client._extract_module_function(script, 57195)
+        assert result == ""
+
+    def test_extract_module_function_handles_nested_braces(self, client):
+        script = """
+        57195:function(e,t,n){
+            var obj = { a: 1, b: { c: 2 } };
+            var arr = [1, { d: 3 }];
+            function inner() { return { e: 4 }; }
+        }
+        """
+        result = client._extract_module_function(script, 57195)
+        assert result.count("{") == result.count("}")
+
+    def test_extract_module_function_handles_strings_with_braces(self, client):
+        script = """
+        57195:function(e,t,n){
+            var str = "text with {braces} inside";
+            var tpl = `template ${value}`;
+        }
+        """
+        result = client._extract_module_function(script, 57195)
+        assert result != ""
+
+    def test_page_size_minimum_is_one(self):
+        client = BytedanceAtsxClient(
+            timeout_seconds=10.0,
+            user_agent="Test",
+            max_pages=1,
+            page_size=0,
+        )
+        assert client.page_size == 1
+
+    @patch("subprocess.run")
+    def test_signed_path_calls_node_script(self, mock_run, client):
+        mock_run.return_value = MagicMock(
+            stdout=json.dumps({"signatures": ["test_signature_123"]}),
+            stderr="",
+        )
+        session = SignedSession(
+            header_profile=HeaderProfile("campus", "campus", "campus"),
+            cookie_values={},
+        )
+        result = client._signed_path(
+            module_source="fake_module_source",
+            base_path="/api/v1/search/job/posts",
+            method="POST",
+            request_payload={"keyword": "test"},
+            referer_url="https://jobs.bytedance.com/campus/position",
+        )
+        assert "_signature=test_signature_123" in result
+        mock_run.assert_called_once()
+
+    @patch("subprocess.run")
+    def test_signed_path_raises_on_empty_signatures(self, mock_run, client):
+        mock_run.return_value = MagicMock(
+            stdout=json.dumps({"signatures": []}),
+            stderr="",
+        )
+        with pytest.raises(RuntimeError, match="签名生成失败"):
+            client._signed_path(
+                module_source="fake",
+                base_path="/api/test",
+                method="GET",
+                request_payload={},
+                referer_url="https://example.com",
+            )

--- a/backend/tests/test_career_collectors.py
+++ b/backend/tests/test_career_collectors.py
@@ -1,5 +1,6 @@
 import asyncio
 from datetime import datetime
+from unittest.mock import MagicMock, patch
 
 from openresume_api.adapters.official import official_adapter
 from openresume_api.career_collectors.base import (
@@ -8,7 +9,19 @@ from openresume_api.career_collectors.base import (
     CollectorRunResult,
     CompanyCollector,
 )
-from openresume_api.career_collectors.manifest import load_sources
+from openresume_api.career_collectors.companies.bytedance import (
+    BytedanceCollector,
+    _first_nested_name,
+    bytedance_collector,
+)
+from openresume_api.career_collectors.manifest import filter_sources, load_sources
+from openresume_api.career_collectors.normalization import (
+    build_description_html,
+    epoch_millis_to_datetime,
+    normalize_city,
+    normalize_multiline_text,
+    normalize_whitespace,
+)
 from openresume_api.career_collectors.runner import CareerCollectorRunner
 from openresume_api.models import CandidateProfile
 from openresume_api.schemas import SearchSessionCreate
@@ -134,3 +147,269 @@ def test_official_adapter_dedupes_records_by_source_site_and_job_id(monkeypatch)
     assert official_adapter.last_run_stats["sources_not_implemented"] == 1
     assert official_adapter.last_run_stats["jobs_before_dedupe"] == 3
     assert official_adapter.last_run_stats["jobs_after_dedupe"] == 2
+
+
+class TestNormalizeWhitespace:
+    def test_removes_extra_spaces(self):
+        assert normalize_whitespace("  hello   world  ") == "hello world"
+
+    def test_replaces_fullwidth_spaces(self):
+        assert normalize_whitespace("hello\u3000world") == "hello world"
+
+    def test_handles_empty_string(self):
+        assert normalize_whitespace("") == ""
+
+    def test_handles_none_like_input(self):
+        assert normalize_whitespace(None) == ""
+
+
+class TestNormalizeMultilineText:
+    def test_removes_empty_lines(self):
+        assert normalize_multiline_text("line1\n\nline2") == "line1\nline2"
+
+    def test_strips_each_line(self):
+        assert normalize_multiline_text("  line1  \n  line2  ") == "line1\nline2"
+
+    def test_handles_empty_string(self):
+        assert normalize_multiline_text("") == ""
+
+
+class TestNormalizeCity:
+    def test_normalizes_beijing_alias(self):
+        assert normalize_city("beijing") == "北京"
+        assert normalize_city("BEIJING") == "北京"
+
+    def test_normalizes_shanghai_alias(self):
+        assert normalize_city("shanghai") == "上海"
+
+    def test_removes_city_suffix(self):
+        assert normalize_city("杭州市") == "杭州"
+
+    def test_handles_compound_location(self):
+        assert normalize_city("北京·上海") == "北京"
+        assert normalize_city("Shanghai, Beijing") == "Shanghai"
+
+    def test_handles_empty_string(self):
+        assert normalize_city("") == ""
+
+
+class TestBuildDescriptionHtml:
+    def test_creates_sections(self):
+        html = build_description_html("做事情", "有经验")
+        assert "<h2>职位描述</h2>" in html
+        assert "<h2>任职要求</h2>" in html
+        assert "<p>做事情</p>" in html
+        assert "<p>有经验</p>" in html
+
+    def test_escapes_html_content(self):
+        html = build_description_html("<script>alert('xss')</script>", "")
+        assert "&lt;script&gt;" in html
+        assert "<script>" not in html
+
+    def test_handles_empty_requirements(self):
+        html = build_description_html("description", "")
+        assert "<h2>职位描述</h2>" in html
+        assert "<h2>任职要求</h2>" not in html
+
+
+class TestEpochMillisToDatetime:
+    def test_converts_millis_to_datetime(self):
+        result = epoch_millis_to_datetime(1704067200000)
+        assert result is not None
+        assert result.year == 2024
+
+    def test_handles_none(self):
+        assert epoch_millis_to_datetime(None) is None
+
+    def test_handles_empty_string(self):
+        assert epoch_millis_to_datetime("") is None
+
+    def test_handles_invalid_value(self):
+        assert epoch_millis_to_datetime("invalid") is None
+
+
+class TestFirstNestedName:
+    def test_extracts_name_key(self):
+        assert _first_nested_name({"name": "Engineering"}) == "Engineering"
+
+    def test_extracts_i18n_name_key(self):
+        assert _first_nested_name({"i18n_name": "工程部门"}) == "工程部门"
+
+    def test_extracts_en_name_key(self):
+        assert _first_nested_name({"en_name": "Engineering Dept"}) == "Engineering Dept"
+
+    def test_prioritizes_name_over_others(self):
+        assert _first_nested_name({"name": "Primary", "i18n_name": "Secondary"}) == "Primary"
+
+    def test_returns_empty_for_non_dict(self):
+        assert _first_nested_name("not a dict") == ""
+        assert _first_nested_name(None) == ""
+        assert _first_nested_name([]) == ""
+
+    def test_returns_empty_for_empty_or_whitespace(self):
+        assert _first_nested_name({"name": "  "}) == ""
+        assert _first_nested_name({"name": ""}) == ""
+
+
+class TestBytedanceCollector:
+    def test_collector_key_is_bytedance(self):
+        assert bytedance_collector.collector_key == "bytedance"
+
+    def test_to_record_returns_none_for_missing_job_id(self):
+        collector = BytedanceCollector()
+        source = make_source(key="test", collector_key="bytedance", variant="experienced")
+        provider = MagicMock()
+        provider.detail_url.return_value = "https://example.com/job/123"
+
+        result = collector._to_record(
+            source,
+            {"id": "", "title": "Engineer"},
+            provider=provider,
+            crawl_time=datetime(2026, 3, 10),
+        )
+        assert result is None
+
+    def test_to_record_returns_none_for_missing_title(self):
+        collector = BytedanceCollector()
+        source = make_source(key="test", collector_key="bytedance", variant="experienced")
+        provider = MagicMock()
+        provider.detail_url.return_value = "https://example.com/job/123"
+
+        result = collector._to_record(
+            source,
+            {"id": "123", "title": ""},
+            provider=provider,
+            crawl_time=datetime(2026, 3, 10),
+        )
+        assert result is None
+
+    def test_to_record_extracts_basic_fields(self):
+        collector = BytedanceCollector()
+        source = make_source(key="test", collector_key="bytedance", variant="experienced")
+        provider = MagicMock()
+        provider.detail_url.return_value = "https://jobs.bytedance.com/experienced/position/123/detail"
+
+        result = collector._to_record(
+            source,
+            {
+                "id": "123",
+                "title": "Senior Frontend Engineer",
+                "description": "Build amazing products",
+                "requirement": "React TypeScript",
+                "city_info": {"name": "上海"},
+                "job_category": {"name": "Engineering"},
+                "publish_time": 1704067200000,
+            },
+            provider=provider,
+            crawl_time=datetime(2026, 3, 10),
+        )
+
+        assert result is not None
+        assert result.job_id == "123"
+        assert result.title == "Senior Frontend Engineer"
+        assert result.description_text == "Build amazing products"
+        assert result.requirements_text == "React TypeScript"
+        assert result.location_city == "上海"
+        assert result.department == "Engineering"
+        assert result.employment_type == "社招"
+        assert result.source_company == "字节跳动"
+
+    def test_to_record_uses_campus_variant(self):
+        collector = BytedanceCollector()
+        source = make_source(key="test", collector_key="bytedance", variant="campus")
+        provider = MagicMock()
+        provider.detail_url.return_value = "https://jobs.bytedance.com/campus/position/123/detail"
+
+        result = collector._to_record(
+            source,
+            {"id": "123", "title": "Engineer"},
+            provider=provider,
+            crawl_time=datetime(2026, 3, 10),
+        )
+
+        assert result is not None
+        assert result.employment_type == "校招"
+
+    def test_to_record_falls_back_to_location_field(self):
+        collector = BytedanceCollector()
+        source = make_source(key="test", collector_key="bytedance", variant="experienced")
+        provider = MagicMock()
+        provider.detail_url.return_value = "https://example.com/job/123"
+
+        result = collector._to_record(
+            source,
+            {"id": "123", "title": "Engineer", "location": "Beijing"},
+            provider=provider,
+            crawl_time=datetime(2026, 3, 10),
+        )
+
+        assert result is not None
+        assert result.location_raw == "Beijing"
+
+    def test_to_record_falls_back_to_job_function_for_department(self):
+        collector = BytedanceCollector()
+        source = make_source(key="test", collector_key="bytedance", variant="experienced")
+        provider = MagicMock()
+        provider.detail_url.return_value = "https://example.com/job/123"
+
+        result = collector._to_record(
+            source,
+            {"id": "123", "title": "Engineer", "job_function": {"name": "Frontend"}},
+            provider=provider,
+            crawl_time=datetime(2026, 3, 10),
+        )
+
+        assert result is not None
+        assert result.department == "Frontend"
+
+
+class TestFilterSources:
+    def test_filters_by_variant(self):
+        sources = load_sources()
+        filtered = filter_sources(sources, variants=["experienced"])
+        assert len(filtered) == 1
+        assert filtered[0].variant == "experienced"
+
+    def test_filters_by_company(self):
+        sources = load_sources()
+        filtered = filter_sources(sources, companies=["字节跳动"])
+        assert len(filtered) == 2
+
+    def test_filters_by_both(self):
+        sources = load_sources()
+        filtered = filter_sources(sources, variants=["campus"], companies=["字节跳动"])
+        assert len(filtered) == 1
+        assert filtered[0].variant == "campus"
+
+    def test_returns_all_when_no_filters(self):
+        sources = load_sources()
+        filtered = filter_sources(sources)
+        assert len(filtered) == len(sources)
+
+    def test_returns_empty_when_no_match(self):
+        sources = load_sources()
+        filtered = filter_sources(sources, variants=["nonexistent"])
+        assert len(filtered) == 0
+
+
+class TestCollectorRunResult:
+    def test_not_implemented_result(self):
+        source = make_source(key="test", collector_key="test", variant="experienced")
+        result = CollectorRunResult.not_implemented(source)
+        assert result.status == "not_implemented"
+        assert result.jobs == []
+        assert result.collector_key == "test"
+
+    def test_success_result_with_stats(self):
+        source = make_source(key="test", collector_key="test", variant="experienced")
+        result = CollectorRunResult(
+            source=source,
+            collector_key="test",
+            status="success",
+            jobs=[make_record(job_id="1")],
+            stats={"returned_jobs": 1},
+            duration_ms=100,
+        )
+        assert result.status == "success"
+        assert len(result.jobs) == 1
+        assert result.duration_ms == 100

--- a/backend/tests/test_matching.py
+++ b/backend/tests/test_matching.py
@@ -5,6 +5,61 @@ from openresume_api.models import CandidateProfile
 from openresume_api.services.matching import matching_service
 
 
+def make_draft(
+    job_id: str,
+    *,
+    title: str = "Frontend Engineer",
+    location_city: str = "Shanghai",
+    location_raw: str = "",
+    salary_min: int | None = 30000,
+    salary_max: int | None = 40000,
+    description_text: str = "React TypeScript",
+    requirements_text: str = "React TypeScript",
+    remote_type: str = "hybrid",
+    posted_at: datetime | None = None,
+    employment_type: str = "Experienced",
+) -> NormalizedJobDraft:
+    return NormalizedJobDraft(
+        source_company="ByteDance",
+        source_site="jobs.bytedance.com",
+        job_id=job_id,
+        title=title,
+        employment_type=employment_type,
+        location_raw=location_raw or location_city,
+        location_city=location_city,
+        location_country="China",
+        remote_type=remote_type,
+        description_text=description_text,
+        requirements_text=requirements_text,
+        apply_url=f"https://jobs.bytedance.com/experienced/position/{job_id}/detail",
+        salary_raw=f"{salary_min}k-{salary_max}k" if salary_min and salary_max else "",
+        salary_min=salary_min,
+        salary_max=salary_max,
+        posted_at=posted_at,
+        raw_payload={"platform": "official"},
+    )
+
+
+def make_profile(
+    *,
+    target_roles: list[str] | None = None,
+    preferred_cities: list[str] | None = None,
+    salary_floor: int = 0,
+    skills: list[str] | None = None,
+    must_have_keywords: list[str] | None = None,
+    years_experience: int = 5,
+) -> CandidateProfile:
+    return CandidateProfile(
+        id=1,
+        target_roles=target_roles or ["Frontend Engineer"],
+        preferred_cities=preferred_cities or ["Shanghai"],
+        salary_floor=salary_floor,
+        skills=skills or ["React", "TypeScript"],
+        must_have_keywords=must_have_keywords or [],
+        years_experience=years_experience,
+    )
+
+
 def test_matching_service_filters_and_scores_expected_roles():
     profile = CandidateProfile(
         id=1,
@@ -68,3 +123,338 @@ def test_matching_service_filters_and_scores_expected_roles():
     assert matches[0].draft.job_id == "1"
     assert matches[0].rule_score > 70
     assert "React" in matches[0].highlights
+
+
+def test_matching_service_filters_by_city():
+    profile = make_profile(preferred_cities=["Beijing"])
+    drafts = [
+        make_draft("1", location_city="Shanghai"),
+        make_draft("2", location_city="Beijing"),
+        make_draft("3", location_city="Shenzhen"),
+    ]
+
+    matches = matching_service.filter_and_score(
+        profile=profile,
+        drafts=drafts,
+        requested_targets=["Frontend Engineer"],
+        requested_cities=["Beijing"],
+        requested_keywords=[],
+        salary_floor=0,
+    )
+
+    assert len(matches) == 1
+    assert matches[0].draft.location_city == "Beijing"
+
+
+def test_matching_service_filters_by_salary_floor():
+    profile = make_profile(salary_floor=30000)
+    drafts = [
+        make_draft("1", salary_min=25000, salary_max=35000),
+        make_draft("2", salary_min=35000, salary_max=45000),
+        make_draft("3", salary_min=None, salary_max=None),
+    ]
+
+    matches = matching_service.filter_and_score(
+        profile=profile,
+        drafts=drafts,
+        requested_targets=["Frontend Engineer"],
+        requested_cities=[],
+        requested_keywords=[],
+        salary_floor=30000,
+    )
+
+    assert len(matches) == 2
+    matched_ids = {m.draft.job_id for m in matches}
+    assert "2" in matched_ids
+    assert "3" in matched_ids
+    assert "1" not in matched_ids
+
+
+def test_matching_service_filters_by_target_role():
+    profile = make_profile(target_roles=["Backend Engineer"])
+    drafts = [
+        make_draft("1", title="Senior Frontend Engineer"),
+        make_draft("2", title="Backend Engineer Python"),
+        make_draft("3", title="Full Stack Engineer"),
+    ]
+
+    matches = matching_service.filter_and_score(
+        profile=profile,
+        drafts=drafts,
+        requested_targets=["Backend Engineer"],
+        requested_cities=[],
+        requested_keywords=[],
+        salary_floor=0,
+    )
+
+    assert len(matches) == 1
+    assert "Backend" in matches[0].draft.title
+
+
+def test_matching_service_filters_by_must_have_keywords():
+    profile = make_profile(must_have_keywords=["React", "TypeScript"])
+    drafts = [
+        make_draft("1", description_text="React TypeScript Node.js"),
+        make_draft("2", description_text="React only"),
+        make_draft("3", description_text="Vue JavaScript"),
+    ]
+
+    matches = matching_service.filter_and_score(
+        profile=profile,
+        drafts=drafts,
+        requested_targets=["Frontend Engineer"],
+        requested_cities=[],
+        requested_keywords=["React", "TypeScript"],
+        salary_floor=0,
+    )
+
+    matched_ids = {m.draft.job_id for m in matches}
+    assert "1" in matched_ids
+    assert "2" in matched_ids
+    assert "3" not in matched_ids
+
+
+def test_matching_service_returns_empty_for_no_matches():
+    profile = make_profile(
+        target_roles=["Frontend Engineer"],
+        preferred_cities=["Shanghai"],
+    )
+    drafts = [
+        make_draft("1", title="Backend Engineer", location_city="Beijing"),
+    ]
+
+    matches = matching_service.filter_and_score(
+        profile=profile,
+        drafts=drafts,
+        requested_targets=["Frontend Engineer"],
+        requested_cities=["Shanghai"],
+        requested_keywords=[],
+        salary_floor=0,
+    )
+
+    assert len(matches) == 0
+
+
+def test_matching_service_handles_empty_drafts():
+    profile = make_profile()
+
+    matches = matching_service.filter_and_score(
+        profile=profile,
+        drafts=[],
+        requested_targets=["Frontend Engineer"],
+        requested_cities=["Shanghai"],
+        requested_keywords=[],
+        salary_floor=0,
+    )
+
+    assert len(matches) == 0
+
+
+def test_matching_service_sorts_by_score_descending():
+    profile = make_profile(skills=["React", "TypeScript", "Node.js", "Python", "Go"])
+    drafts = [
+        make_draft("1", description_text="React TypeScript Node.js Python Go"),
+        make_draft("2", description_text="React TypeScript"),
+        make_draft("3", description_text="React"),
+    ]
+
+    matches = matching_service.filter_and_score(
+        profile=profile,
+        drafts=drafts,
+        requested_targets=["Frontend Engineer"],
+        requested_cities=[],
+        requested_keywords=[],
+        salary_floor=0,
+    )
+
+    assert len(matches) == 3
+    assert matches[0].rule_score >= matches[1].rule_score
+    assert matches[1].rule_score >= matches[2].rule_score
+
+
+def test_matching_service_detects_onsite_risk_flag():
+    profile = make_profile()
+    drafts = [
+        make_draft("1", remote_type="onsite"),
+        make_draft("2", remote_type="hybrid"),
+        make_draft("3", remote_type="remote"),
+    ]
+
+    matches = matching_service.filter_and_score(
+        profile=profile,
+        drafts=drafts,
+        requested_targets=["Frontend Engineer"],
+        requested_cities=[],
+        requested_keywords=[],
+        salary_floor=0,
+    )
+
+    onsite_match = next((m for m in matches if m.draft.job_id == "1"), None)
+    assert onsite_match is not None
+    assert "需要现场办公" in onsite_match.risk_flags
+
+    hybrid_match = next((m for m in matches if m.draft.job_id == "2"), None)
+    assert hybrid_match is not None
+    assert "需要现场办公" not in hybrid_match.risk_flags
+
+
+def test_matching_service_detects_leadership_risk_flag():
+    profile = make_profile()
+    drafts = [
+        make_draft("1", description_text="Team leader position"),
+        make_draft("2", description_text="Individual contributor"),
+    ]
+
+    matches = matching_service.filter_and_score(
+        profile=profile,
+        drafts=drafts,
+        requested_targets=["Frontend Engineer"],
+        requested_cities=[],
+        requested_keywords=[],
+        salary_floor=0,
+    )
+
+    leader_match = next((m for m in matches if m.draft.job_id == "1"), None)
+    assert leader_match is not None
+    assert "可能包含管理职责" in leader_match.risk_flags
+
+
+def test_matching_service_detects_experience_risk_flag():
+    profile = make_profile(years_experience=2)
+    drafts = [
+        make_draft("1", description_text="3-5 years experience required"),
+        make_draft("2", description_text="Entry level position"),
+    ]
+
+    matches = matching_service.filter_and_score(
+        profile=profile,
+        drafts=drafts,
+        requested_targets=["Frontend Engineer"],
+        requested_cities=[],
+        requested_keywords=[],
+        salary_floor=0,
+    )
+
+    exp_match = next((m for m in matches if m.draft.job_id == "1"), None)
+    assert exp_match is not None
+    assert "经验要求可能偏高" in exp_match.risk_flags
+
+
+def test_matching_service_uses_profile_defaults_when_request_empty():
+    profile = make_profile(
+        target_roles=["Frontend Engineer"],
+        preferred_cities=["Shanghai"],
+        skills=["React"],
+        must_have_keywords=["React"],
+    )
+    drafts = [
+        make_draft("1", location_city="Shanghai", description_text="React Frontend"),
+        make_draft("2", location_city="Beijing", description_text="Vue Backend"),
+    ]
+
+    matches = matching_service.filter_and_score(
+        profile=profile,
+        drafts=drafts,
+        requested_targets=[],
+        requested_cities=[],
+        requested_keywords=[],
+        salary_floor=0,
+    )
+
+    assert len(matches) == 1
+    assert matches[0].draft.job_id == "1"
+
+
+def test_matching_service_handles_missing_optional_fields():
+    profile = make_profile()
+    drafts = [
+        make_draft("1", posted_at=None, requirements_text="", salary_min=None),
+    ]
+
+    matches = matching_service.filter_and_score(
+        profile=profile,
+        drafts=drafts,
+        requested_targets=["Frontend Engineer"],
+        requested_cities=[],
+        requested_keywords=[],
+        salary_floor=0,
+    )
+
+    assert len(matches) == 1
+    assert matches[0].rule_score > 0
+
+
+def test_matching_service_limits_highlights_to_five():
+    profile = make_profile(skills=["React", "TypeScript", "Node.js", "Python", "Go", "Rust", "Java"])
+    drafts = [
+        make_draft("1", description_text="React TypeScript Node.js Python Go Rust Java"),
+    ]
+
+    matches = matching_service.filter_and_score(
+        profile=profile,
+        drafts=drafts,
+        requested_targets=["Frontend Engineer"],
+        requested_cities=[],
+        requested_keywords=[],
+        salary_floor=0,
+    )
+
+    assert len(matches[0].highlights) <= 5
+
+
+def test_matching_service_limits_missing_keywords_to_four():
+    profile = make_profile(must_have_keywords=["A", "B", "C", "D", "E", "F"])
+    drafts = [
+        make_draft("1", description_text="Only A and B mentioned"),
+    ]
+
+    matches = matching_service.filter_and_score(
+        profile=profile,
+        drafts=drafts,
+        requested_targets=["Frontend Engineer"],
+        requested_cities=[],
+        requested_keywords=["A", "B", "C", "D", "E", "F"],
+        salary_floor=0,
+    )
+
+    assert len(matches[0].missing_keywords) <= 4
+
+
+def test_matching_service_normalizes_city_names():
+    profile = make_profile(preferred_cities=["上海"])
+    drafts = [
+        make_draft("1", location_city="Shanghai"),
+        make_draft("2", location_city="北京"),
+    ]
+
+    matches = matching_service.filter_and_score(
+        profile=profile,
+        drafts=drafts,
+        requested_targets=["Frontend Engineer"],
+        requested_cities=["上海"],
+        requested_keywords=[],
+        salary_floor=0,
+    )
+
+    assert len(matches) == 1
+    assert matches[0].draft.location_city == "Shanghai"
+
+
+def test_matching_service_case_insensitive_matching():
+    profile = make_profile(target_roles=["FRONTEND ENGINEER"])
+    drafts = [
+        make_draft("1", title="frontend engineer"),
+        make_draft("2", title="FRONTEND ENGINEER"),
+        make_draft("3", title="Frontend Engineer"),
+    ]
+
+    matches = matching_service.filter_and_score(
+        profile=profile,
+        drafts=drafts,
+        requested_targets=["FRONTEND ENGINEER"],
+        requested_cities=[],
+        requested_keywords=[],
+        salary_floor=0,
+    )
+
+    assert len(matches) == 3

--- a/skills/openresume-career-site-adapter/SKILL.md
+++ b/skills/openresume-career-site-adapter/SKILL.md
@@ -34,6 +34,18 @@ Use this skill to turn a company career homepage into real job detail extraction
 - `backend/openresume_api/adapters/official_extractors/common.py`
   Use for title cleanup, city normalization, salary parsing, directory classification, and quality scoring.
 
+## Recruitment Type Variants
+
+All adapters must support three standard recruitment types. Use `$openresume-recruitment-variants` skill for details.
+
+| Variant | Label | Description |
+|---------|-------|-------------|
+| `experienced` | 社招 | Social recruitment for experienced professionals |
+| `campus` | 校招 | Campus recruitment for fresh graduates |
+| `internship` | 实习 | Internship for current students |
+
+When adding a new company source, define all three variants in `manifest.py` if the site supports them.
+
 ## Rules
 
 - Start from the homepage and assume it may only contain links to the real search pages.
@@ -43,6 +55,7 @@ Use this skill to turn a company career homepage into real job detail extraction
 - If a homepage links into a filtered share page, try the canonical unfiltered list page as well before accepting a zero-result API response.
 - Do not relax hard filters to make a site look green. If everything is filtered as directory or noise, extraction is still wrong.
 - Keep `raw_payload.quality` truthful so matching logic keeps working.
+- Always define all three recruitment type variants (experienced/campus/internship) for each company source.
 
 ## Reference
 

--- a/skills/openresume-career-site-adapter/references/provider-patterns.md
+++ b/skills/openresume-career-site-adapter/references/provider-patterns.md
@@ -53,6 +53,53 @@
 - If page props are empty, search loaded chunks for `api/` paths, tab routes, or `router.push` targets.
 - Follow secondary routes such as `/grad`, `/intern`, or tab-specific pages before concluding that the site has no jobs.
 
+## Recruitment Type Variants (招聘类型变体)
+
+所有网站适配器必须支持三种标准招聘类型变体：
+
+| Variant | 中文标签 | 英文标签 | 说明 |
+|---------|----------|----------|------|
+| `experienced` | 社招 | Social Recruitment | 面向有工作经验的求职者 |
+| `campus` | 校招 | Campus Recruitment | 面向应届毕业生的校园招聘 |
+| `internship` | 实习 | Internship | 面向在校学生的实习岗位 |
+
+### 实现要求
+
+1. **Source 定义**：每个公司的数据源必须定义完整的 variant 配置
+   ```python
+   CareerSiteSource(
+       key="company-experienced",  # 格式: {company}-{variant}
+       company_name="公司名称",
+       entry_url="https://...",
+       source_site="jobs.company.com",
+       collector_key="company",
+       variant="experienced",  # 必须是 experienced/campus/internship 之一
+       label="公司社招",
+   )
+   ```
+
+2. **前端映射**：前端已定义标准标签映射（[SearchFilterSidebar.tsx](file:///d:/my%20project/OpenResume/src/components/SearchFilterSidebar.tsx)）
+   ```typescript
+   const VARIANT_LABELS: Record<string, string> = {
+     experienced: "社招",
+     campus: "校招",
+     internship: "实习",
+   };
+   ```
+
+3. **API 端点**：
+   - `GET /api/sources` - 返回所有可用数据源，包含 variant 字段
+   - `GET /api/source-variants` - 返回可用的招聘类型列表
+   - 搜索时通过 `source_variants` 参数过滤
+
+### 各提供商的 Variant 映射
+
+| 提供商 | experienced | campus | internship |
+|--------|-------------|--------|------------|
+| ByteDance | `/experienced/position` | `/campus/position` | 需要新增 |
+| Taobao/Taotian | 社招入口 | `campusType=freshman` | `campusType=internship` |
+| PDD | 社招入口 | `/campus/grad` | `/campus/intern` |
+
 ## General heuristics
 
 - `candidate_count = 0` usually means the wrong page level, the wrong extractor hint, or a provider-specific token or signature flow that has not been replicated yet.

--- a/skills/openresume-recruitment-variants/SKILL.md
+++ b/skills/openresume-recruitment-variants/SKILL.md
@@ -1,0 +1,114 @@
+---
+name: openresume-recruitment-variants
+description: Define and implement recruitment type variants (experienced/campus/internship) for career site adapters. Use when adding new company sources, updating existing extractors, or ensuring variant compliance across the pipeline.
+---
+
+# OpenResume Recruitment Variants
+
+This skill defines the standard recruitment type variants that all career site adapters must support.
+
+## Standard Variants
+
+| Variant | Chinese Label | English Label | Target Audience |
+|---------|---------------|---------------|-----------------|
+| `experienced` | 社招 | Social Recruitment | Experienced professionals |
+| `campus` | 校招 | Campus Recruitment | Fresh graduates |
+| `internship` | 实习 | Internship | Current students |
+
+## Implementation Checklist
+
+When adding or updating a company adapter, ensure:
+
+### 1. Source Definition (manifest.py)
+
+```python
+SOURCES: tuple[CareerSiteSource, ...] = (
+    CareerSiteSource(
+        key="{company}-experienced",
+        company_name="公司名称",
+        entry_url="https://...",
+        source_site="jobs.company.com",
+        collector_key="{company}",
+        variant="experienced",
+        label="公司社招",
+    ),
+    CareerSiteSource(
+        key="{company}-campus",
+        company_name="公司名称",
+        entry_url="https://...",
+        source_site="jobs.company.com",
+        collector_key="{company}",
+        variant="campus",
+        label="公司校招",
+    ),
+    CareerSiteSource(
+        key="{company}-internship",
+        company_name="公司名称",
+        entry_url="https://...",
+        source_site="jobs.company.com",
+        collector_key="{company}",
+        variant="internship",
+        label="公司实习",
+    ),
+)
+```
+
+### 2. Collector Implementation
+
+The collector must handle all three variants:
+
+```python
+VARIANT_CONFIGS = {
+    "experienced": VariantConfig(...),
+    "campus": VariantConfig(...),
+    "internship": VariantConfig(...),
+}
+```
+
+### 3. API Endpoints
+
+- `GET /api/sources` - Returns all sources with variant field
+- `GET /api/source-variants` - Returns available variants list
+- `POST /api/search-sessions` - Accepts `source_variants` filter
+
+### 4. Frontend Integration
+
+Frontend already has standard labels in [SearchFilterSidebar.tsx](file:///d:/my%20project/OpenResume/src/components/SearchFilterSidebar.tsx):
+
+```typescript
+const VARIANT_LABELS: Record<string, string> = {
+  experienced: "社招",
+  campus: "校招",
+  internship: "实习",
+};
+```
+
+## Variant Detection Patterns
+
+### URL Patterns
+
+| Variant | Common URL Patterns |
+|---------|---------------------|
+| experienced | `/experienced`, `/social`, `/society`, `/job` |
+| campus | `/campus`, `/grad`, `/graduate`, `/fresh` |
+| internship | `/intern`, `/internship`, `/trainee` |
+
+### API Parameters
+
+| Variant | Common Parameters |
+|---------|-------------------|
+| experienced | `portal_type=2`, `type=social`, `recruitType=1` |
+| campus | `portal_type=3`, `type=campus`, `recruitType=2`, `campusType=freshman` |
+| internship | `type=intern`, `recruitType=3`, `campusType=internship` |
+
+## Rules
+
+1. Every company source MUST define all three variants if the target site supports them
+2. If a site only supports a subset, document the limitation in the source definition
+3. Variant values must be lowercase: `experienced`, `campus`, `internship`
+4. Source key format: `{company_key}-{variant}`
+5. Labels should follow pattern: `{公司名}{类型}` (e.g., "字节跳动社招")
+
+## Reference
+
+Read `references/provider-patterns.md` for provider-specific variant implementations.

--- a/skills/openresume-recruitment-variants/agents/openai.yaml
+++ b/skills/openresume-recruitment-variants/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Recruitment Variants"
+  short_description: "Define and implement recruitment type variants (experienced/campus/internship)."
+  default_prompt: "Use $openresume-recruitment-variants to ensure proper variant support when adding or updating career site adapters."

--- a/src/components/SearchFilterSidebar.tsx
+++ b/src/components/SearchFilterSidebar.tsx
@@ -1,0 +1,177 @@
+import { useQuery } from "@tanstack/react-query";
+import { api } from "../lib/api";
+
+const VARIANT_LABELS: Record<string, string> = {
+  experienced: "\u793e\u62db",
+  campus: "\u6821\u62db",
+  internship: "\u5b9e\u4e60",
+};
+
+interface SearchFilterSidebarProps {
+  selectedVariants: string[];
+  selectedCompanies: string[];
+  onVariantsChange: (variants: string[]) => void;
+  onCompaniesChange: (companies: string[]) => void;
+}
+
+export function SearchFilterSidebar({
+  selectedVariants,
+  selectedCompanies,
+  onVariantsChange,
+  onCompaniesChange,
+}: SearchFilterSidebarProps) {
+  const variantsQuery = useQuery({
+    queryKey: ["source-variants"],
+    queryFn: api.getSourceVariants,
+  });
+
+  const companiesQuery = useQuery({
+    queryKey: ["source-companies"],
+    queryFn: api.getSourceCompanies,
+  });
+
+  const handleVariantToggle = (variant: string) => {
+    if (selectedVariants.includes(variant)) {
+      onVariantsChange(selectedVariants.filter((v) => v !== variant));
+    } else {
+      onVariantsChange([...selectedVariants, variant]);
+    }
+  };
+
+  const handleCompanyToggle = (company: string) => {
+    if (selectedCompanies.includes(company)) {
+      onCompaniesChange(selectedCompanies.filter((c) => c !== company));
+    } else {
+      onCompaniesChange([...selectedCompanies, company]);
+    }
+  };
+
+  const handleSelectAllVariants = () => {
+    if (variantsQuery.data) {
+      onVariantsChange([...variantsQuery.data]);
+    }
+  };
+
+  const handleClearVariants = () => {
+    onVariantsChange([]);
+  };
+
+  const handleSelectAllCompanies = () => {
+    if (companiesQuery.data) {
+      onCompaniesChange([...companiesQuery.data]);
+    }
+  };
+
+  const handleClearCompanies = () => {
+    onCompaniesChange([]);
+  };
+
+  return (
+    <aside className="space-y-6">
+      <section className="rounded-[32px] border border-ink/10 bg-shell/90 p-6 shadow-console">
+        <div className="flex items-center justify-between">
+          <p className="text-xs uppercase tracking-[0.24em] text-slate">
+            \u62db\u8058\u7c7b\u578b
+          </p>
+          <div className="flex gap-2">
+            <button
+              type="button"
+              onClick={handleSelectAllVariants}
+              className="rounded-lg px-2 py-1 text-xs text-slate hover:bg-paper hover:text-ink"
+            >
+              \u5168\u9009
+            </button>
+            <button
+              type="button"
+              onClick={handleClearVariants}
+              className="rounded-lg px-2 py-1 text-xs text-slate hover:bg-paper hover:text-ink"
+            >
+              \u6e05\u7a7a
+            </button>
+          </div>
+        </div>
+        <div className="mt-4 space-y-2">
+          {variantsQuery.data?.map((variant) => {
+            const checked = selectedVariants.includes(variant);
+            const label = VARIANT_LABELS[variant] || variant;
+            return (
+              <label
+                key={variant}
+                className={`flex cursor-pointer items-center gap-3 rounded-2xl border px-4 py-3 transition ${
+                  checked
+                    ? "border-ink/30 bg-ink text-shell"
+                    : "border-ink/10 bg-paper text-ink hover:border-ink/20"
+                }`}
+              >
+                <input
+                  type="checkbox"
+                  checked={checked}
+                  onChange={() => handleVariantToggle(variant)}
+                  className="mt-0.5"
+                />
+                <span className="text-sm font-medium">{label}</span>
+              </label>
+            );
+          })}
+        </div>
+        {selectedVariants.length === 0 && (
+          <p className="mt-3 text-xs text-slate">
+            \u672a\u9009\u62e9\u65f6\u5c06\u641c\u7d22\u6240\u6709\u7c7b\u578b
+          </p>
+        )}
+      </section>
+
+      <section className="rounded-[32px] border border-ink/10 bg-shell/90 p-6 shadow-console">
+        <div className="flex items-center justify-between">
+          <p className="text-xs uppercase tracking-[0.24em] text-slate">
+            \u641c\u7d22\u516c\u53f8
+          </p>
+          <div className="flex gap-2">
+            <button
+              type="button"
+              onClick={handleSelectAllCompanies}
+              className="rounded-lg px-2 py-1 text-xs text-slate hover:bg-paper hover:text-ink"
+            >
+              \u5168\u9009
+            </button>
+            <button
+              type="button"
+              onClick={handleClearCompanies}
+              className="rounded-lg px-2 py-1 text-xs text-slate hover:bg-paper hover:text-ink"
+            >
+              \u6e05\u7a7a
+            </button>
+          </div>
+        </div>
+        <div className="mt-4 space-y-2">
+          {companiesQuery.data?.map((company) => {
+            const checked = selectedCompanies.includes(company);
+            return (
+              <label
+                key={company}
+                className={`flex cursor-pointer items-center gap-3 rounded-2xl border px-4 py-3 transition ${
+                  checked
+                    ? "border-ink/30 bg-ink text-shell"
+                    : "border-ink/10 bg-paper text-ink hover:border-ink/20"
+                }`}
+              >
+                <input
+                  type="checkbox"
+                  checked={checked}
+                  onChange={() => handleCompanyToggle(company)}
+                  className="mt-0.5"
+                />
+                <span className="text-sm font-medium">{company}</span>
+              </label>
+            );
+          })}
+        </div>
+        {selectedCompanies.length === 0 && (
+          <p className="mt-3 text-xs text-slate">
+            \u672a\u9009\u62e9\u65f6\u5c06\u641c\u7d22\u6240\u6709\u516c\u53f8
+          </p>
+        )}
+      </section>
+    </aside>
+  );
+}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -13,6 +13,7 @@ import type {
   RuntimeConfig,
   RuntimeConfigUpdatePayload,
   SearchSession,
+  SourceInfo,
   VerificationWindowPayload,
 } from "../types";
 
@@ -151,12 +152,17 @@ export const api = {
     cities: string[];
     salary_floor: number;
     must_have_keywords: string[];
+    source_variants?: string[];
+    source_companies?: string[];
   }) =>
     request<SearchSession>("/api/search-sessions", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify(payload),
     }),
+  getSources: () => request<SourceInfo[]>("/api/sources"),
+  getSourceVariants: () => request<string[]>("/api/sources/variants"),
+  getSourceCompanies: () => request<string[]>("/api/sources/companies"),
   listSearchSessions: () => request<SearchSession[]>("/api/search-sessions"),
   getSearchSession: (id: string) => request<SearchSession>(`/api/search-sessions/${id}`),
   retrySearchSession: (id: string) =>

--- a/src/pages/SearchPage.tsx
+++ b/src/pages/SearchPage.tsx
@@ -2,6 +2,7 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { AlertTriangle, Search as SearchIcon, ShieldAlert } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
 import { useNavigate } from "react-router-dom";
+import { SearchFilterSidebar } from "../components/SearchFilterSidebar";
 import { api } from "../lib/api";
 import { splitCommaValues } from "../lib/utils";
 import type { AutomationMode, PlatformCapability } from "../types";
@@ -50,6 +51,8 @@ export function SearchPage() {
   const [cities, setCities] = useState("");
   const [salaryFloor, setSalaryFloor] = useState("0");
   const [mustHaveKeywords, setMustHaveKeywords] = useState("");
+  const [selectedVariants, setSelectedVariants] = useState<string[]>([]);
+  const [selectedCompanies, setSelectedCompanies] = useState<string[]>([]);
 
   const platformsQuery = useQuery({
     queryKey: ["platforms"],
@@ -129,6 +132,8 @@ export function SearchPage() {
         cities: splitCommaValues(cities),
         salary_floor: Number(salaryFloor),
         must_have_keywords: splitCommaValues(mustHaveKeywords),
+        source_variants: selectedVariants.length > 0 ? selectedVariants : undefined,
+        source_companies: selectedCompanies.length > 0 ? selectedCompanies : undefined,
       }),
     onSuccess: (session) => {
       queryClient.invalidateQueries({ queryKey: ["search-sessions"] });
@@ -142,8 +147,6 @@ export function SearchPage() {
       : null;
 
   const searchDisabled =
-    selectedPlatformCapabilities.length === 0 ||
-    !modeSupported(selectedPlatformCapabilities, mode) ||
     searchMutation.isPending ||
     (mode === "guided_apply" && !guidedApplyEnabled);
 
@@ -160,7 +163,14 @@ export function SearchPage() {
         </p>
       </section>
 
-      <section className="grid gap-6 xl:grid-cols-[1.1fr_0.9fr]">
+      <section className="grid gap-6 xl:grid-cols-[0.25fr_1fr_0.9fr]">
+        <SearchFilterSidebar
+          selectedVariants={selectedVariants}
+          selectedCompanies={selectedCompanies}
+          onVariantsChange={setSelectedVariants}
+          onCompaniesChange={setSelectedCompanies}
+        />
+
         <div className="space-y-6">
           <div className="grid gap-4 md:grid-cols-3">
             {modeCards.map((entry) => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -212,3 +212,10 @@ export interface VerificationWindowPayload {
   title: string;
   message: string;
 }
+
+export interface SourceInfo {
+  key: string;
+  company_name: string;
+  variant: string;
+  label: string;
+}


### PR DESCRIPTION
- 新增 openresume-recruitment-variants Skill 定义三种标准招聘类型
- 更新 provider-patterns.md 添加变体实现规范
- 为字节跳动添加 internship variant 支持
- 更新前端和后端 API 支持三种招聘类型过滤