### PR TITLE
修复前端时间显示问题

### DIFF
--- a/src/components/Timeline.tsx
+++ b/src/components/Timeline.tsx
@@ -1,4 +1,5 @@
 import type { SearchEvent } from "../types";
+import { formatTime } from "../lib/utils";
 
 function eventTypeLabel(type: string) {
   const mapping: Record<string, string> = {
@@ -47,7 +48,7 @@ export function Timeline({ events }: TimelineProps) {
             <div>
               <p className="text-sm font-semibold text-ink">{event.message}</p>
               <p className="mt-1 text-xs uppercase tracking-[0.18em] text-slate">
-                {eventTypeLabel(event.type)} | {new Date(event.timestamp).toLocaleTimeString()}
+                {eventTypeLabel(event.type)} | {formatTime(event.timestamp)}
               </p>
             </div>
           </div>

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -67,3 +67,38 @@ export function statusTone(status: string) {
       return "bg-ink/10 text-ink";
   }
 }
+
+/**
+ * 格式化 UTC 时间字符串为本地时间显示
+ * 后端返回的时间是 UTC 时间但不带时区标识，需要手动添加 'Z' 后缀
+ */
+export function formatDateTime(utcTimeString: string): string {
+  if (!utcTimeString) return "";
+  // 如果时间字符串不包含时区信息，添加 'Z' 表示 UTC
+  const timeString = utcTimeString.endsWith("Z") ? utcTimeString : `${utcTimeString}Z`;
+  const date = new Date(timeString);
+  return date.toLocaleString("zh-CN", {
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+    hour12: false,
+  });
+}
+
+/**
+ * 格式化 UTC 时间字符串为本地时间（仅时分秒）
+ */
+export function formatTime(utcTimeString: string): string {
+  if (!utcTimeString) return "";
+  const timeString = utcTimeString.endsWith("Z") ? utcTimeString : `${utcTimeString}Z`;
+  const date = new Date(timeString);
+  return date.toLocaleTimeString("zh-CN", {
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+    hour12: false,
+  });
+}

--- a/src/pages/HistoryPage.tsx
+++ b/src/pages/HistoryPage.tsx
@@ -3,7 +3,7 @@ import { AlertOctagon } from "lucide-react";
 import { useNavigate } from "react-router-dom";
 import { StatusPill } from "../components/StatusPill";
 import { api } from "../lib/api";
-import { modeLabel, pillLabel } from "../lib/utils";
+import { formatDateTime, modeLabel, pillLabel } from "../lib/utils";
 
 async function openVerificationPopup(url: string, title: string) {
   if (window.openResumeDesktop?.openVerificationWindow) {
@@ -101,7 +101,7 @@ export function HistoryPage() {
                         .map((platform) => pillLabel(platform))
                         .join(" | ")}{" "}
                       | {modeLabel(session.mode)} |{" "}
-                      {new Date(session.created_at).toLocaleString()}
+                      {formatDateTime(session.created_at)}
                     </p>
                     {session.analysis_notice ? (
                       <p className="mt-2 text-sm leading-6 text-slate">
@@ -142,7 +142,7 @@ export function HistoryPage() {
                 </p>
                 <p className="mt-1 text-sm text-slate">
                   {pillLabel(attempt.platform)} | {modeLabel(attempt.mode)} |{" "}
-                  {new Date(attempt.created_at).toLocaleString()}
+                  {formatDateTime(attempt.created_at)}
                 </p>
                 <p className="mt-2 text-sm leading-7 text-slate">{attempt.message}</p>
               </div>


### PR DESCRIPTION
问题：
- 后端使用 datetime.now(UTC) 返回 UTC 时间但移除了时区信息
- 前端使用 new Date() 解析时会误认为本地时间，导致时间显示错误

解决方案：
- 在 src/lib/utils.ts 添加 formatDateTime 和 formatTime 函数
- 这些函数会为 UTC 时间字符串添加 'Z' 后缀，确保正确解析为 UTC 时间
- 然后使用 toLocaleString 转换为本地时间显示

修改文件：
- src/lib/utils.ts: 新增时间格式化工具函数
- src/components/Timeline.tsx: 使用 formatTime 显示事件时间
- src/pages/HistoryPage.tsx: 使用 formatDateTime 显示搜索和投递记录时间