### PR TITLE
功能：结果页面自动加载最近一次搜索结果

### DIFF
--- a/src/pages/ResultsPage.tsx
+++ b/src/pages/ResultsPage.tsx
@@ -54,11 +54,28 @@ function sessionRefetchInterval(
 }
 
 export function ResultsPage() {
-  const [params] = useSearchParams();
+  const [params, setParams] = useSearchParams();
   const queryClient = useQueryClient();
   const [events, setEvents] = useState<SearchEvent[]>([]);
   const [currentPage, setCurrentPage] = useState(1);
-  const sessionId = params.get("session") || undefined;
+  const sessionIdFromUrl = params.get("session") || undefined;
+
+  // 获取搜索历史列表，用于在没有 session 参数时加载最近一次搜索
+  const sessionsListQuery = useQuery({
+    queryKey: ["search-sessions"],
+    queryFn: api.listSearchSessions,
+    enabled: !sessionIdFromUrl,
+  });
+
+  // 如果 URL 没有 session 参数，自动使用最近一次的搜索结果
+  const sessionId = sessionIdFromUrl || sessionsListQuery.data?.[0]?.id;
+
+  // 当自动加载最近搜索时，更新 URL 参数
+  useEffect(() => {
+    if (!sessionIdFromUrl && sessionId) {
+      setParams({ session: sessionId }, { replace: true });
+    }
+  }, [sessionIdFromUrl, sessionId, setParams]);
 
   useEffect(() => {
     setEvents([]);


### PR DESCRIPTION
问题：
- 直接访问结果页面（不带 session 参数）时显示空白
- 用户需要先从搜索历史跳转才能看到结果

解决方案：
- 当 URL 没有 session 参数时，自动查询搜索历史列表
- 使用最近一次搜索的 ID 作为默认 session
- 自动更新 URL 参数（使用 replace: true 避免增加历史记录）

用户体验改进：
- 从搜索历史跳转 → 显示对应的搜索结果（原有行为）
- 直接点击侧边栏"结果面板" → 自动显示最近一次搜索结果（新功能）
- 如果从未搜索过 → 显示空状态（原有行为保持不变）

修改文件：
- src/pages/ResultsPage.tsx: 添加自动加载最近搜索结果的逻辑