### PR TITLE
Fix AI runtime integration and manual analysis flow

### DIFF
--- a/backend/openresume_api/automation/official_drivers.py
+++ b/backend/openresume_api/automation/official_drivers.py
@@ -16,6 +16,7 @@ class OfficialDriverConfig:
     company_key: str
     display_name: str
     login_markers: tuple[str, ...]
+    session_ready_markers: tuple[str, ...]
     captcha_markers: tuple[str, ...]
     form_open_selectors: tuple[str, ...]
     resume_upload_selectors: tuple[str, ...]
@@ -65,6 +66,14 @@ COMMON_LOGIN_MARKERS = (
     "login",
     "\u8d26\u53f7\u767b\u5f55",
 )
+COMMON_SESSION_READY_MARKERS = (
+    "\u9000\u51fa\u767b\u5f55",
+    "log out",
+    "sign out",
+    "\u4e2a\u4eba\u4e2d\u5fc3",
+    "\u6211\u7684\u6295\u9012",
+    "\u6211\u7684\u7533\u8bf7",
+)
 COMMON_CAPTCHA_MARKERS = (
     "\u9a8c\u8bc1\u7801",
     "captcha",
@@ -83,6 +92,7 @@ def _config(
     company_key: str,
     display_name: str,
     login_markers: tuple[str, ...] = COMMON_LOGIN_MARKERS,
+    session_ready_markers: tuple[str, ...] = (),
     login_launch_mode: LoginLaunchMode = "direct",
     login_open_selectors: tuple[str, ...] = (),
     login_ready_wait_ms: int = 1200,
@@ -92,6 +102,7 @@ def _config(
         company_key=company_key,
         display_name=display_name,
         login_markers=login_markers,
+        session_ready_markers=session_ready_markers,
         captcha_markers=COMMON_CAPTCHA_MARKERS,
         form_open_selectors=COMMON_FORM_OPEN_SELECTORS,
         resume_upload_selectors=COMMON_RESUME_UPLOAD_SELECTORS,
@@ -125,6 +136,12 @@ CONFIGS: dict[str, OfficialDriverConfig] = {
         company_key="tencent",
         display_name="\u817e\u8baf",
         login_markers=COMMON_LOGIN_MARKERS + ("\u626b\u7801\u767b\u5f55", "QQ\u767b\u5f55"),
+        session_ready_markers=COMMON_SESSION_READY_MARKERS
+        + (
+            "\u6295\u9012\u8bb0\u5f55",
+            "\u6211\u7684\u5fd7\u613f",
+            "\u6211\u7684\u7b80\u5386",
+        ),
     ),
     "tme": _config(
         company_key="tme",
@@ -313,6 +330,11 @@ class GenericOfficialDriver:
             and not any(marker in current_url for marker in COMMON_LOGIN_URL_MARKERS)
         ):
             return True, f"{self.config.display_name} 登录缓存可用。"
+
+        if self.config.session_ready_markers and await page.content_contains(
+            list(self.config.session_ready_markers)
+        ):
+            return True, f"{self.config.display_name} \u767b\u5f55\u7f13\u5b58\u53ef\u7528\u3002"
 
         if await page.content_contains(list(self.config.login_markers)):
             return (

--- a/backend/openresume_api/automation/playwright_runtime.py
+++ b/backend/openresume_api/automation/playwright_runtime.py
@@ -8,6 +8,8 @@ from typing import TypeVar
 from .base import ApplyExecutionOutcome, AutomationPage
 
 ResultT = TypeVar("ResultT")
+DESKTOP_VIEWPORT = {"width": 1440, "height": 960}
+INTERACTIVE_BROWSER_ARGS = ["--start-maximized"]
 
 
 class PlaywrightAutomationPage:
@@ -96,6 +98,24 @@ class PlaywrightAutomationPage:
 
 
 class PlaywrightAutomationRuntime:
+    @staticmethod
+    def _context_kwargs(state_path: Path, *, interactive: bool) -> dict[str, object]:
+        context_kwargs: dict[str, object] = {}
+        if state_path.exists():
+            context_kwargs["storage_state"] = str(state_path)
+        if interactive:
+            context_kwargs["no_viewport"] = True
+        else:
+            context_kwargs["viewport"] = dict(DESKTOP_VIEWPORT)
+        return context_kwargs
+
+    @staticmethod
+    def _launch_kwargs(*, headless: bool, interactive: bool) -> dict[str, object]:
+        launch_kwargs: dict[str, object] = {"headless": headless}
+        if interactive and not headless:
+            launch_kwargs["args"] = list(INTERACTIVE_BROWSER_ARGS)
+        return launch_kwargs
+
     async def inspect(
         self,
         *,
@@ -114,10 +134,10 @@ class PlaywrightAutomationRuntime:
         state_path.parent.mkdir(parents=True, exist_ok=True)
 
         async with async_playwright() as playwright:
-            browser = await playwright.chromium.launch(headless=headless)
-            context_kwargs = {}
-            if state_path.exists():
-                context_kwargs["storage_state"] = str(state_path)
+            browser = await playwright.chromium.launch(
+                **self._launch_kwargs(headless=headless, interactive=False)
+            )
+            context_kwargs = self._context_kwargs(state_path, interactive=False)
             context = await browser.new_context(**context_kwargs)
             page = await context.new_page()
             try:
@@ -159,10 +179,10 @@ class PlaywrightAutomationRuntime:
         state_path.parent.mkdir(parents=True, exist_ok=True)
 
         async with async_playwright() as playwright:
-            browser = await playwright.chromium.launch(headless=False)
-            context_kwargs = {}
-            if state_path.exists():
-                context_kwargs["storage_state"] = str(state_path)
+            browser = await playwright.chromium.launch(
+                **self._launch_kwargs(headless=False, interactive=True)
+            )
+            context_kwargs = self._context_kwargs(state_path, interactive=True)
             context = await browser.new_context(**context_kwargs)
             page = await context.new_page()
             done = asyncio.get_running_loop().create_future()
@@ -202,10 +222,10 @@ class PlaywrightAutomationRuntime:
         state_path.parent.mkdir(parents=True, exist_ok=True)
 
         async with async_playwright() as playwright:
-            browser = await playwright.chromium.launch(headless=False)
-            context_kwargs = {}
-            if state_path.exists():
-                context_kwargs["storage_state"] = str(state_path)
+            browser = await playwright.chromium.launch(
+                **self._launch_kwargs(headless=False, interactive=True)
+            )
+            context_kwargs = self._context_kwargs(state_path, interactive=True)
             context = await browser.new_context(**context_kwargs)
             page = await context.new_page()
             done = asyncio.get_running_loop().create_future()

--- a/backend/openresume_api/main.py
+++ b/backend/openresume_api/main.py
@@ -997,6 +997,14 @@ async def retry_search_session(session_id: str, db: SessionDep):
 
 
 @app.post(
+    "/api/search-sessions/{session_id}/start-analysis",
+    response_model=SearchSessionResponse,
+)
+async def start_search_analysis(session_id: str, db: SessionDep):
+    return await search_service.start_analysis(db, session_id)
+
+
+@app.post(
     "/api/search-sessions/{session_id}/open-verification",
     response_model=VerificationWindowResponse,
 )

--- a/backend/openresume_api/services/llm.py
+++ b/backend/openresume_api/services/llm.py
@@ -9,6 +9,7 @@ import httpx
 from sqlmodel import Session
 
 from ..models import CandidateProfile, JobListing, LLMAnalysisCache
+from .llm_common import extract_chat_message_text
 from .profile import profile_service
 from .runtime_config import LLMRuntimeConfig, runtime_config_service
 
@@ -43,6 +44,9 @@ class AnalysisBatch:
 
 class LLMConfigurationError(RuntimeError):
     pass
+
+
+OPENAI_ANALYZE_TIMEOUT_SECONDS = 90.0
 
 
 def job_content_hash(job: JobListing) -> str:
@@ -290,7 +294,7 @@ class OpenAICompatibleLLMProvider:
             "Content-Type": "application/json",
             "Authorization": f"Bearer {self.config.openai_api_key}",
         }
-        async with httpx.AsyncClient(timeout=45.0) as client:
+        async with httpx.AsyncClient(timeout=OPENAI_ANALYZE_TIMEOUT_SECONDS) as client:
             response = await client.post(
                 f"{self.config.openai_base_url.rstrip('/')}/chat/completions",
                 headers=headers,
@@ -299,7 +303,8 @@ class OpenAICompatibleLLMProvider:
             response.raise_for_status()
             data = response.json()
 
-        content = data.get("choices", [{}])[0].get("message", {}).get("content", "")
+        message = data.get("choices", [{}])[0].get("message", {})
+        content = extract_chat_message_text(message if isinstance(message, dict) else {})
         parsed = self._extract_json(content)
         items = parsed.get("results", [])
         results_by_job = {
@@ -348,7 +353,7 @@ class LLMService:
         if llm_config.llm_provider == "openai_compatible":
             if llm_state.configured:
                 return OpenAICompatibleLLMProvider(llm_config)
-            raise LLMConfigurationError(llm_state.notice)
+            return HeuristicLLMProvider(notice=llm_state.notice)
         return HeuristicLLMProvider(notice=llm_state.notice)
 
     def _cached_results(

--- a/backend/openresume_api/services/llm_common.py
+++ b/backend/openresume_api/services/llm_common.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+
+def _normalize_message_text(value: object) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, str):
+        return value.strip()
+    if isinstance(value, list):
+        parts: list[str] = []
+        for item in value:
+            if isinstance(item, str):
+                text = item.strip()
+                if text:
+                    parts.append(text)
+                continue
+            if not isinstance(item, dict):
+                continue
+            for key in ("text", "content"):
+                nested = item.get(key)
+                if isinstance(nested, str) and nested.strip():
+                    parts.append(nested.strip())
+                    break
+                if isinstance(nested, dict):
+                    nested_text = nested.get("value") or nested.get("text")
+                    if isinstance(nested_text, str) and nested_text.strip():
+                        parts.append(nested_text.strip())
+                        break
+        return "\n".join(parts).strip()
+    return str(value).strip()
+
+
+def extract_chat_message_text(message: dict | None) -> str:
+    normalized_message = message or {}
+    primary = _normalize_message_text(normalized_message.get("content"))
+    if primary:
+        return primary
+    reasoning = _normalize_message_text(normalized_message.get("reasoning_content"))
+    if reasoning:
+        return reasoning
+    tool_calls = normalized_message.get("tool_calls")
+    if isinstance(tool_calls, list):
+        parts: list[str] = []
+        for item in tool_calls:
+            if not isinstance(item, dict):
+                continue
+            function = item.get("function")
+            if not isinstance(function, dict):
+                continue
+            arguments = function.get("arguments")
+            if isinstance(arguments, str) and arguments.strip():
+                parts.append(arguments.strip())
+        if parts:
+            return "\n".join(parts).strip()
+    return ""

--- a/backend/openresume_api/services/official_sites.py
+++ b/backend/openresume_api/services/official_sites.py
@@ -38,7 +38,7 @@ OFFICIAL_SITE_DESCRIPTORS: tuple[OfficialSiteDescriptor, ...] = (
         company_name="\u817e\u8baf",
         label="\u817e\u8baf\u5b98\u7f51",
         login_url="https://careers.tencent.com/login.html?state=https%3A%2F%2Fcareers.tencent.com%2F",
-        session_check_url="https://careers.tencent.com/login.html?state=https%3A%2F%2Fcareers.tencent.com%2F",
+        session_check_url="https://careers.tencent.com/",
         source_sites=("careers.tencent.com", "join.qq.com"),
         supported_variants=ALL_VARIANTS,
         aliases=("Tencent", "QQ"),

--- a/backend/openresume_api/services/runtime_config.py
+++ b/backend/openresume_api/services/runtime_config.py
@@ -7,6 +7,7 @@ import time
 import httpx
 
 from ..config import settings
+from .llm_common import extract_chat_message_text
 
 
 @dataclass
@@ -192,11 +193,8 @@ class RuntimeConfigService:
             payload = response.json()
 
         latency_ms = int((time.perf_counter() - started_at) * 1000)
-        content = (
-            payload.get("choices", [{}])[0]
-            .get("message", {})
-            .get("content", "")
-        )
+        message = payload.get("choices", [{}])[0].get("message", {})
+        content = extract_chat_message_text(message if isinstance(message, dict) else {})
         return {
             "latency_ms": latency_ms,
             "reply_preview": str(content).strip()[:160] or None,

--- a/backend/openresume_api/services/search.py
+++ b/backend/openresume_api/services/search.py
@@ -331,6 +331,50 @@ class SearchService:
         asyncio.create_task(self._run_pipeline(session.id, self._payload_from_session(session)))
         return session
 
+    async def start_analysis(self, db: Session, session_id: str) -> SearchSession:
+        session = db.get(SearchSession, session_id)
+        if not session:
+            raise HTTPException(status_code=404, detail="Search session not found.")
+        if session.status != "ready":
+            raise HTTPException(
+                status_code=409,
+                detail="Search results are not ready for analysis.",
+            )
+        if session.analysis_status == "running":
+            raise HTTPException(status_code=409, detail="Analysis is already running.")
+        if session.analysis_status == "ready":
+            raise HTTPException(status_code=409, detail="Analysis has already finished.")
+
+        for match in db.exec(
+            select(JobMatch).where(JobMatch.session_id == session_id)
+        ).all():
+            match.analysis_degraded = False
+            match.analysis_notice = None
+            db.add(match)
+
+        session.analysis_status = "running"
+        session.analysis_degraded = False
+        session.analysis_notice = None
+        session.summary = "Search results are ready. AI analysis is running."
+        session.updated_at = datetime.utcnow()
+        db.add(session)
+        db.commit()
+        db.refresh(session)
+
+        self._set_session_meta(
+            db,
+            session_id,
+            llm_ms=None,
+            time_to_llm_enriched_ms=None,
+        )
+        event_bus.publish(
+            session_id,
+            "llm_started",
+            "AI analysis started. Results will refresh when it finishes.",
+        )
+        asyncio.create_task(self._run_llm_enrichment(session_id))
+        return session
+
     async def reopen_verification(self, db: Session, session_id: str) -> dict[str, str]:
         session = db.get(SearchSession, session_id)
         if not session:
@@ -579,7 +623,7 @@ class SearchService:
                 session.analysis_degraded = False
                 session.analysis_notice = None
                 session.blocked_reason = None
-                session.summary = "Search results are ready. LLM analysis is running in background."
+                session.summary = "Search results are ready. AI analysis is waiting to start."
                 session.updated_at = datetime.utcnow()
                 db.add(session)
                 db.commit()
@@ -599,9 +643,8 @@ class SearchService:
                 event_bus.publish(
                     session_id,
                     "ready",
-                    "Results are ready. LLM analysis will update them in background.",
+                    "Results are ready. Start AI analysis when you want enhanced ranking.",
                 )
-                asyncio.create_task(self._run_llm_enrichment(session_id))
             except PlatformBlockedError as error:
                 detail = str(error)
                 verification_url = error.verification_url
@@ -666,15 +709,18 @@ class SearchService:
             if not session or session.status != "ready":
                 return
 
-            session.analysis_status = "running"
-            session.updated_at = datetime.utcnow()
-            db.add(session)
-            db.commit()
-            event_bus.publish(
-                session_id,
-                "llm_started",
-                "LLM analysis started in background.",
-            )
+            if session.analysis_status == "pending":
+                session.analysis_status = "running"
+                session.updated_at = datetime.utcnow()
+                db.add(session)
+                db.commit()
+                event_bus.publish(
+                    session_id,
+                    "llm_started",
+                    "AI analysis started. Results will refresh when it finishes.",
+                )
+            elif session.analysis_status != "running":
+                return
 
             try:
                 profile = db.get(CandidateProfile, 1) or CandidateProfile(id=1)
@@ -794,7 +840,7 @@ class SearchService:
                 session.analysis_provider = provider
                 session.analysis_degraded = degraded
                 session.analysis_notice = notice
-                session.summary = "Search finished. LLM analysis has been applied."
+                session.summary = "Search finished. AI analysis has been applied."
                 session.updated_at = datetime.utcnow()
                 db.add(session)
                 db.commit()
@@ -823,7 +869,7 @@ class SearchService:
                     session.analysis_status = "failed"
                     session.analysis_degraded = True
                     session.analysis_notice = detail
-                    session.summary = "Search finished, but background LLM analysis failed."
+                    session.summary = "Search finished, but AI analysis failed."
                     session.updated_at = datetime.utcnow()
                     db.add(session)
                     db.commit()

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -131,6 +131,10 @@ def create_search_session(
     )
 
 
+def start_search_analysis(client, session_id: str):
+    return client.post(f"/api/search-sessions/{session_id}/start-analysis")
+
+
 def sample_draft() -> NormalizedJobDraft:
     return NormalizedJobDraft(
         source_company="ByteDance",
@@ -443,11 +447,17 @@ def test_search_pipeline_marks_ready_before_background_llm_finishes(client, monk
     session = create_search_session(client)
     assert session.status_code == 200
 
-    ready = wait_for_session_status(client, session.json()["id"], "ready")
-    assert ready["analysis_status"] in {"pending", "running"}
+    session_id = session.json()["id"]
+    ready = wait_for_session_status(client, session_id, "ready")
+    assert ready["analysis_status"] == "pending"
     assert ready["analysis_degraded"] is False
 
-    matches = client.get(f"/api/search-sessions/{session.json()['id']}/matches")
+    time.sleep(0.7)
+    still_pending = client.get(f"/api/search-sessions/{session_id}")
+    assert still_pending.status_code == 200
+    assert still_pending.json()["analysis_status"] == "pending"
+
+    matches = client.get(f"/api/search-sessions/{session_id}/matches")
     assert matches.status_code == 200
     payload = matches.json()
     assert len(payload) == 1
@@ -460,12 +470,16 @@ def test_search_pipeline_marks_ready_before_background_llm_finishes(client, monk
     assert payload[0]["llm_score"] is None
     assert payload[0]["analysis_degraded"] is False
 
-    enriched = wait_for_analysis_status(client, session.json()["id"], "ready")
+    started = start_search_analysis(client, session_id)
+    assert started.status_code == 200
+    assert started.json()["analysis_status"] == "running"
+
+    enriched = wait_for_analysis_status(client, session_id, "ready")
     assert enriched["analysis_provider"] == "heuristic"
     assert enriched["analysis_degraded"] is True
     assert enriched["analysis_notice"] == "background analysis complete"
 
-    enriched_matches = client.get(f"/api/search-sessions/{session.json()['id']}/matches")
+    enriched_matches = client.get(f"/api/search-sessions/{session_id}/matches")
     assert enriched_matches.status_code == 200
     enriched_payload = enriched_matches.json()
     assert enriched_payload[0]["llm_score"] == 88.0
@@ -509,6 +523,8 @@ def test_search_pipeline_records_stage_timings_in_session_meta(client, monkeypat
     session_id = session.json()["id"]
 
     wait_for_session_status(client, session_id, "ready")
+    started = start_search_analysis(client, session_id)
+    assert started.status_code == 200
     wait_for_analysis_status(client, session_id, "ready")
 
     with Session(db_module.engine) as db:
@@ -523,6 +539,64 @@ def test_search_pipeline_records_stage_timings_in_session_meta(client, monkeypat
     assert isinstance(meta.get("llm_ms"), int)
     assert isinstance(meta.get("time_to_llm_enriched_ms"), int)
     assert meta["time_to_llm_enriched_ms"] >= meta["time_to_ready_ms"]
+
+
+def test_search_analysis_requires_explicit_start_and_rejects_duplicate_starts(
+    client, monkeypatch
+):
+    upsert_profile(client)
+
+    async def fake_search_jobs(search, profile):
+        return [sample_draft()]
+
+    async def fake_analyze_jobs(db, profile, jobs):
+        await asyncio.sleep(0.2)
+        return AnalysisBatch(
+            metadata=AnalysisMetadata(
+                provider="heuristic",
+                degraded=False,
+                notice=None,
+            ),
+            results=[
+                LLMResult(
+                    cache_key=f"cache-{job.job_id}",
+                    job_id=job.job_id,
+                    llm_score=91.0,
+                    highlights=["React"],
+                    missing_keywords=[],
+                    risk_flags=[],
+                    llm_summary="started manually",
+                )
+                for job in jobs
+            ],
+        )
+
+    monkeypatch.setattr(official_adapter, "search_jobs", fake_search_jobs)
+    monkeypatch.setattr(llm_service, "analyze_jobs", fake_analyze_jobs)
+
+    session = create_search_session(client)
+    assert session.status_code == 200
+    session_id = session.json()["id"]
+
+    wait_for_session_status(client, session_id, "ready")
+    detail = client.get(f"/api/search-sessions/{session_id}")
+    assert detail.status_code == 200
+    assert detail.json()["analysis_status"] == "pending"
+
+    first_start = start_search_analysis(client, session_id)
+    assert first_start.status_code == 200
+    assert first_start.json()["analysis_status"] == "running"
+
+    duplicate_start = start_search_analysis(client, session_id)
+    assert duplicate_start.status_code == 409
+    assert "already running" in duplicate_start.json()["detail"]
+
+    finished = wait_for_analysis_status(client, session_id, "ready")
+    assert finished["analysis_provider"] == "heuristic"
+
+    completed_start = start_search_analysis(client, session_id)
+    assert completed_start.status_code == 409
+    assert "already finished" in completed_start.json()["detail"]
 
 
 def test_search_matches_merge_same_job_id_with_multi_locations(client, monkeypatch):
@@ -1140,9 +1214,12 @@ def test_search_pipeline_only_applies_llm_to_first_120_matches(client, monkeypat
     )
     assert session.status_code == 200
 
-    wait_for_session_status(client, session.json()["id"], "ready")
-    wait_for_analysis_status(client, session.json()["id"], "ready")
-    matches = client.get(f"/api/search-sessions/{session.json()['id']}/matches")
+    session_id = session.json()["id"]
+    wait_for_session_status(client, session_id, "ready")
+    started = start_search_analysis(client, session_id)
+    assert started.status_code == 200
+    wait_for_analysis_status(client, session_id, "ready")
+    matches = client.get(f"/api/search-sessions/{session_id}/matches")
     assert matches.status_code == 200
 
     payload = matches.json()
@@ -1395,6 +1472,8 @@ def test_search_pipeline_recomputes_diversity_scores_after_llm_enrichment(
 
     assert initial_order == ["a-1", "jd-1", "mt-1", "a-2"]
 
+    started = start_search_analysis(client, session_id)
+    assert started.status_code == 200
     wait_for_analysis_status(client, session_id, "ready")
     enriched = client.get(f"/api/search-sessions/{session_id}/matches")
     assert enriched.status_code == 200
@@ -1426,15 +1505,19 @@ def test_background_llm_failure_does_not_roll_back_ready_session(client, monkeyp
     session = create_search_session(client)
     assert session.status_code == 200
 
-    ready = wait_for_session_status(client, session.json()["id"], "ready")
-    assert ready["analysis_status"] in {"pending", "running"}
+    session_id = session.json()["id"]
+    ready = wait_for_session_status(client, session_id, "ready")
+    assert ready["analysis_status"] == "pending"
 
-    failed = wait_for_analysis_status(client, session.json()["id"], "failed")
+    started = start_search_analysis(client, session_id)
+    assert started.status_code == 200
+
+    failed = wait_for_analysis_status(client, session_id, "failed")
     assert failed["status"] == "ready"
     assert failed["analysis_degraded"] is True
     assert "background llm crashed" in (failed["analysis_notice"] or "")
 
-    matches = client.get(f"/api/search-sessions/{session.json()['id']}/matches")
+    matches = client.get(f"/api/search-sessions/{session_id}/matches")
     assert matches.status_code == 200
     payload = matches.json()
     assert len(payload) == 1
@@ -1475,12 +1558,15 @@ def test_openai_failure_falls_back_to_heuristic(client, monkeypatch):
     session = create_search_session(client)
     assert session.status_code == 200
 
-    wait_for_session_status(client, session.json()["id"], "ready")
-    enriched = wait_for_analysis_status(client, session.json()["id"], "ready")
+    session_id = session.json()["id"]
+    wait_for_session_status(client, session_id, "ready")
+    started = start_search_analysis(client, session_id)
+    assert started.status_code == 200
+    enriched = wait_for_analysis_status(client, session_id, "ready")
     assert enriched["analysis_degraded"] is True
     assert "LLM" in (enriched["analysis_notice"] or "")
 
-    matches = client.get(f"/api/search-sessions/{session.json()['id']}/matches")
+    matches = client.get(f"/api/search-sessions/{session_id}/matches")
     assert matches.status_code == 200
     assert len(matches.json()) == 1
 

--- a/backend/tests/test_llm.py
+++ b/backend/tests/test_llm.py
@@ -1,0 +1,278 @@
+import asyncio
+from datetime import datetime
+
+import httpx
+from openresume_api.adapters.base import NormalizedJobDraft
+from openresume_api.adapters.official import official_adapter
+from openresume_api.models import CandidateProfile, JobListing
+from openresume_api.services.llm import OpenAICompatibleLLMProvider
+from openresume_api.services.llm_common import extract_chat_message_text
+from openresume_api.services.runtime_config import LLMRuntimeConfig
+
+
+def sample_profile() -> CandidateProfile:
+    return CandidateProfile(
+        id=1,
+        full_name="Test Candidate",
+        headline="Senior Frontend Engineer",
+        summary="React TypeScript engineer",
+        target_roles=["Frontend Engineer"],
+        preferred_cities=["Shanghai"],
+        salary_floor=25000,
+        years_experience=5,
+        degree="Bachelor",
+        skills=["React", "TypeScript"],
+        must_have_keywords=["React"],
+        tech_stack=["React", "TypeScript"],
+        project_experiences=[],
+        awards=[],
+        source_language="zh-CN",
+        raw_text="React TypeScript",
+    )
+
+
+def sample_job() -> JobListing:
+    return JobListing(
+        session_id="session-1",
+        platform="official",
+        source_company="ByteDance",
+        source_site="jobs.bytedance.com",
+        job_id="job-1",
+        title="Frontend Engineer",
+        description_text="Need React and TypeScript",
+        requirements_text="Strong React",
+        salary_min=30000,
+        salary_max=40000,
+        crawl_time=datetime(2026, 3, 10),
+    )
+
+
+def sample_draft() -> NormalizedJobDraft:
+    return NormalizedJobDraft(
+        source_company="ByteDance",
+        source_site="jobs.bytedance.com",
+        job_id="official-live-001",
+        title="Senior Frontend Engineer",
+        department="Engineering",
+        employment_type="Experienced",
+        location_raw="Shanghai",
+        location_city="Shanghai",
+        location_country="China",
+        remote_type="onsite",
+        description_html="<p>React TypeScript official site flow</p>",
+        description_text="React TypeScript official site flow",
+        requirements_text="React TypeScript",
+        skills_extracted=[],
+        posted_at=datetime(2026, 3, 1),
+        apply_url="https://jobs.bytedance.com/experienced/position/official-live-001/detail",
+        salary_raw="25K-35K",
+        salary_min=25000,
+        salary_max=35000,
+        lang="zh-CN",
+        crawl_time=datetime(2026, 3, 10),
+        raw_payload={"source": "test", "platform": "official"},
+    )
+
+
+def wait_for_session_status(client, session_id: str, expected: str, timeout: float = 5.0):
+    import time
+
+    deadline = time.time() + timeout
+    latest = None
+    while time.time() < deadline:
+        response = client.get(f"/api/search-sessions/{session_id}")
+        assert response.status_code == 200
+        latest = response.json()
+        if latest["status"] == expected:
+            return latest
+        time.sleep(0.15)
+    raise AssertionError(f"session {session_id} did not reach status={expected}: {latest}")
+
+
+def wait_for_analysis_status(client, session_id: str, expected: str, timeout: float = 5.0):
+    import time
+
+    deadline = time.time() + timeout
+    latest = None
+    while time.time() < deadline:
+        response = client.get(f"/api/search-sessions/{session_id}")
+        assert response.status_code == 200
+        latest = response.json()
+        if latest["analysis_status"] == expected:
+            return latest
+        time.sleep(0.15)
+    raise AssertionError(
+        f"session {session_id} did not reach analysis_status={expected}: {latest}"
+    )
+
+
+def upsert_profile(client):
+    response = client.put(
+        "/api/profile",
+        json={
+            "id": 1,
+            "full_name": "Test Candidate",
+            "headline": "Senior Frontend Engineer",
+            "summary": "React and TypeScript engineer",
+            "target_roles": ["Frontend Engineer"],
+            "preferred_cities": ["Shanghai"],
+            "salary_floor": 25000,
+            "years_experience": 5,
+            "degree": "Bachelor",
+            "skills": ["React", "TypeScript"],
+            "must_have_keywords": ["React", "TypeScript"],
+            "tech_stack": ["React", "TypeScript"],
+            "project_experiences": [],
+            "awards": [],
+            "source_filename": None,
+            "source_language": "zh-CN",
+            "raw_text": "React TypeScript resume",
+        },
+    )
+    assert response.status_code == 200
+
+
+def create_search_session(client):
+    return client.post(
+        "/api/search-sessions",
+        json={
+            "platforms": ["official"],
+            "mode": "recommend_only",
+            "job_targets": ["Frontend Engineer"],
+            "cities": ["Shanghai"],
+            "salary_floor": 0,
+            "must_have_keywords": [],
+            "source_variants": [],
+            "source_companies": [],
+            "match_limit": 20,
+            "company_job_limit": 20,
+            "force_refresh": False,
+        },
+    )
+
+
+def test_extract_chat_message_text_supports_reasoning_and_tool_calls():
+    assert extract_chat_message_text({"content": "OK"}) == "OK"
+    assert (
+        extract_chat_message_text({"content": None, "reasoning_content": "JSON here"})
+        == "JSON here"
+    )
+    assert (
+        extract_chat_message_text(
+            {
+                "content": [{"type": "text", "text": "hello"}],
+                "reasoning_content": "fallback",
+            }
+        )
+        == "hello"
+    )
+    assert (
+        extract_chat_message_text(
+            {
+                "tool_calls": [
+                    {"function": {"arguments": '{"results": []}'}},
+                ]
+            }
+        )
+        == '{"results": []}'
+    )
+
+
+def test_openai_provider_can_parse_json_from_reasoning_content(monkeypatch):
+    provider = OpenAICompatibleLLMProvider(
+        LLMRuntimeConfig(
+            llm_provider="openai_compatible",
+            openai_base_url="https://example.com/v1",
+            openai_api_key="secret",
+            openai_model="test-model",
+        )
+    )
+
+    payload = {
+        "choices": [
+            {
+                "message": {
+                    "content": None,
+                    "reasoning_content": (
+                        '{"results": [{"job_id": "job-1", "llm_score": 92, '
+                        '"highlights": ["React"], "missing_keywords": [], '
+                        '"risk_flags": [], "llm_summary": "Strong match"}]}'
+                    ),
+                }
+            }
+        ]
+    }
+
+    class FakeResponse:
+        def raise_for_status(self) -> None:
+            return None
+
+        def json(self) -> dict:
+            return payload
+
+    class FakeClient:
+        def __init__(self, *args, **kwargs) -> None:
+            return None
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb) -> None:
+            return None
+
+        async def post(self, url: str, headers: dict, json: dict) -> FakeResponse:
+            assert url == "https://example.com/v1/chat/completions"
+            assert json["model"] == "test-model"
+            return FakeResponse()
+
+    monkeypatch.setattr(httpx, "AsyncClient", FakeClient)
+
+    results = asyncio.run(provider.analyze(sample_profile(), [sample_job()]))
+
+    assert len(results) == 1
+    assert results[0].job_id == "job-1"
+    assert results[0].llm_score == 92.0
+    assert results[0].llm_summary == "Strong match"
+    assert results[0].highlights == ["React"]
+
+
+def test_incomplete_openai_config_falls_back_to_heuristic_in_search_pipeline(
+    client, monkeypatch
+):
+    upsert_profile(client)
+
+    async def fake_search_jobs(search, profile):
+        return [sample_draft()]
+
+    monkeypatch.setattr(official_adapter, "search_jobs", fake_search_jobs)
+
+    update = client.put(
+        "/api/runtime-config",
+        json={
+            "llm_provider": "openai_compatible",
+            "openai_base_url": "https://example.com/v1",
+            "openai_model": None,
+            "openai_api_key": "secret-key-123456",
+            "replace_api_key": True,
+        },
+    )
+    assert update.status_code == 200
+    assert update.json()["llm_configured"] is False
+
+    session = create_search_session(client)
+    assert session.status_code == 200
+    session_id = session.json()["id"]
+
+    wait_for_session_status(client, session_id, "ready")
+    enriched = wait_for_analysis_status(client, session_id, "ready")
+    assert enriched["analysis_provider"] == "heuristic"
+    assert enriched["analysis_degraded"] is True
+    assert "缺少必要配置" in (enriched["analysis_notice"] or "")
+
+    matches = client.get(f"/api/search-sessions/{session_id}/matches")
+    assert matches.status_code == 200
+    payload = matches.json()
+    assert len(payload) == 1
+    assert payload[0]["analysis_provider"] == "heuristic"
+    assert payload[0]["analysis_degraded"] is True
+    assert payload[0]["llm_score"] is not None

--- a/backend/tests/test_official_account_pool.py
+++ b/backend/tests/test_official_account_pool.py
@@ -432,6 +432,57 @@ def test_check_session_accepts_redirect_away_from_login_page():
     assert "登录缓存可用" in message
 
 
+def test_tencent_check_session_accepts_homepage_ready_markers():
+    class FakePage:
+        def __init__(self):
+            self.url = ""
+
+        async def goto(self, url: str) -> None:
+            self.url = "https://careers.tencent.com/"
+
+        async def current_url(self) -> str:
+            return self.url
+
+        async def wait_for_timeout(self, milliseconds: int) -> None:
+            return None
+
+        async def try_click(self, selectors: list[str]) -> str | None:
+            return None
+
+        async def evaluate(self, script: str) -> object:
+            return None
+
+        async def content_contains(self, markers: list[str]) -> bool:
+            marker_set = {marker.casefold() for marker in markers}
+            if "\u6295\u9012\u8bb0\u5f55".casefold() in marker_set:
+                return True
+            if "\u767b\u5f55".casefold() in marker_set:
+                return True
+            return False
+
+        async def has_any(self, selectors: list[str]) -> str | None:
+            return None
+
+        async def try_set_input_files(self, selectors: list[str], file_path: str) -> str | None:
+            return None
+
+        async def try_fill(self, selectors: list[str], value: str) -> str | None:
+            return None
+
+    driver = get_official_driver("tencent")
+    site = get_official_site("tencent")
+    ready, message = asyncio.run(
+        driver.check_session(
+            FakePage(),
+            target_url=site.session_check_url or site.login_url,
+        )
+    )
+
+    assert ready is True
+    assert site.session_check_url == "https://careers.tencent.com/"
+    assert "\u767b\u5f55\u7f13\u5b58\u53ef\u7528" in message
+
+
 def test_official_account_login_and_session_test_update_binary_status(client, monkeypatch):
     class FakeRuntime:
         def __init__(self):

--- a/backend/tests/test_playwright_runtime.py
+++ b/backend/tests/test_playwright_runtime.py
@@ -1,0 +1,180 @@
+import asyncio
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+from openresume_api.automation.playwright_runtime import (
+    DESKTOP_VIEWPORT,
+    INTERACTIVE_BROWSER_ARGS,
+    PlaywrightAutomationRuntime,
+)
+
+
+class FakePage:
+    def __init__(self) -> None:
+        self.goto_calls: list[tuple[str, str]] = []
+
+    async def goto(self, url: str, wait_until: str = "domcontentloaded") -> None:
+        self.goto_calls.append((url, wait_until))
+
+    async def content(self) -> str:
+        return ""
+
+
+class FakeContext:
+    def __init__(self) -> None:
+        self.page = FakePage()
+        self.storage_state_paths: list[str] = []
+        self.closed = False
+
+    async def new_page(self) -> FakePage:
+        return self.page
+
+    async def storage_state(self, *, path: str) -> None:
+        self.storage_state_paths.append(path)
+
+    async def close(self) -> None:
+        self.closed = True
+
+
+class FakeBrowser:
+    def __init__(self) -> None:
+        self.new_context_calls: list[dict[str, object]] = []
+        self.contexts: list[FakeContext] = []
+        self.handlers: dict[str, object] = {}
+        self.closed = False
+
+    async def new_context(self, **kwargs) -> FakeContext:
+        self.new_context_calls.append(kwargs)
+        context = FakeContext()
+        self.contexts.append(context)
+        return context
+
+    def on(self, event: str, handler) -> None:
+        self.handlers[event] = handler
+
+    def is_connected(self) -> bool:
+        return not self.closed
+
+    async def close(self) -> None:
+        self.closed = True
+
+
+class FakeChromium:
+    def __init__(self) -> None:
+        self.launch_calls: list[dict[str, object]] = []
+        self.browsers: list[FakeBrowser] = []
+
+    async def launch(self, **kwargs) -> FakeBrowser:
+        self.launch_calls.append(kwargs)
+        browser = FakeBrowser()
+        self.browsers.append(browser)
+        return browser
+
+
+class FakePlaywright:
+    def __init__(self) -> None:
+        self.chromium = FakeChromium()
+
+
+class FakeAsyncPlaywright:
+    def __init__(self, playwright: FakePlaywright) -> None:
+        self._playwright = playwright
+
+    async def __aenter__(self) -> FakePlaywright:
+        return self._playwright
+
+    async def __aexit__(self, exc_type, exc, tb) -> None:
+        return None
+
+
+def install_fake_playwright(monkeypatch, fake_playwright: FakePlaywright) -> None:
+    module = SimpleNamespace(
+        async_playwright=lambda: FakeAsyncPlaywright(fake_playwright)
+    )
+    monkeypatch.setitem(sys.modules, "playwright.async_api", module)
+
+
+def test_interactive_run_uses_maximized_browser_and_no_viewport(tmp_path, monkeypatch):
+    runtime = PlaywrightAutomationRuntime()
+    fake_playwright = FakePlaywright()
+    install_fake_playwright(monkeypatch, fake_playwright)
+
+    state_path = tmp_path / "storage-state.json"
+    state_path.write_text("{}", encoding="utf-8")
+
+    async def callback(page) -> None:
+        return None
+
+    async def completion_callback() -> bool:
+        return True
+
+    asyncio.run(
+        runtime.interactive_run(
+            storage_state_path=str(state_path),
+            callback=callback,
+            completion_callback=completion_callback,
+            timeout_seconds=1,
+        )
+    )
+
+    assert fake_playwright.chromium.launch_calls == [
+        {"headless": False, "args": list(INTERACTIVE_BROWSER_ARGS)}
+    ]
+    browser = fake_playwright.chromium.browsers[0]
+    assert browser.new_context_calls == [
+        {"storage_state": str(state_path), "no_viewport": True}
+    ]
+    assert browser.contexts[0].storage_state_paths[-1] == str(state_path)
+
+
+def test_interactive_capture_uses_maximized_browser_and_no_viewport(
+    tmp_path, monkeypatch
+):
+    runtime = PlaywrightAutomationRuntime()
+    fake_playwright = FakePlaywright()
+    install_fake_playwright(monkeypatch, fake_playwright)
+
+    state_path = tmp_path / "storage-state.json"
+
+    asyncio.run(
+        runtime.interactive_capture(
+            storage_state_path=str(state_path),
+            target_url="https://careers.tencent.com/login.html",
+            timeout_seconds=0,
+        )
+    )
+
+    assert fake_playwright.chromium.launch_calls == [
+        {"headless": False, "args": list(INTERACTIVE_BROWSER_ARGS)}
+    ]
+    browser = fake_playwright.chromium.browsers[0]
+    assert browser.new_context_calls == [{"no_viewport": True}]
+    assert browser.contexts[0].page.goto_calls == [
+        ("https://careers.tencent.com/login.html", "domcontentloaded")
+    ]
+
+
+def test_inspect_uses_desktop_viewport_for_headless_checks(tmp_path, monkeypatch):
+    runtime = PlaywrightAutomationRuntime()
+    fake_playwright = FakePlaywright()
+    install_fake_playwright(monkeypatch, fake_playwright)
+
+    state_path = tmp_path / "storage-state.json"
+
+    async def callback(page) -> tuple[bool, str]:
+        return True, "ok"
+
+    result = asyncio.run(
+        runtime.inspect(
+            storage_state_path=str(state_path),
+            headless=True,
+            callback=callback,
+        )
+    )
+
+    assert result == (True, "ok")
+    assert fake_playwright.chromium.launch_calls == [{"headless": True}]
+    browser = fake_playwright.chromium.browsers[0]
+    assert browser.new_context_calls == [{"viewport": dict(DESKTOP_VIEWPORT)}]
+    assert browser.contexts[0].storage_state_paths[-1] == str(state_path)

--- a/skills/openresume-official-login-session-fix/SKILL.md
+++ b/skills/openresume-official-login-session-fix/SKILL.md
@@ -75,6 +75,18 @@ If the new bug is close to a previous one, do not add a new workflow.
 - Reuse frontend auto-provision of a default account for "login button disabled with no account".
 - Only create a new helper if the same patch would otherwise be repeated in 2 or more places.
 
+## Tencent pattern
+
+Tencent careers exposed a repeatable failure mode worth reusing:
+
+- Do not probe `https://careers.tencent.com/login.html?...` as the session-check target after login.
+- Use the homepage `https://careers.tencent.com/` as `session_check_url` instead, because successful auth may keep login-related text in the shell even when the session is valid.
+- In `official_drivers.py`, check positive signed-in markers before negative login markers when the site can render both at once.
+- For Tencent, reliable positive markers included `投递记录`, `我的志愿`, `我的简历`, plus generic signed-in markers such as `退出登录` and `个人中心`.
+- Add a focused fake-page test in `backend/tests/test_official_account_pool.py` that returns both a positive Tencent marker and a generic login marker, and assert the session is treated as logged in.
+
+Use the same pattern for other SPAs that stay on a login-like shell or keep a global "登录" header after authentication.
+
 ## Verification
 
 Prefer lightweight checks first:

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -174,6 +174,10 @@ export const api = {
   getSourceCompanies: () => request<string[]>("/api/sources/companies"),
   listSearchSessions: () => request<SearchSession[]>("/api/search-sessions"),
   getSearchSession: (id: string) => request<SearchSession>(`/api/search-sessions/${id}`),
+  startSearchAnalysis: (id: string) =>
+    request<SearchSession>(`/api/search-sessions/${id}/start-analysis`, {
+      method: "POST",
+    }),
   retrySearchSession: (id: string) =>
     request<SearchSession>(`/api/search-sessions/${id}/retry`, {
       method: "POST",

--- a/src/pages/ResultsPage.tsx
+++ b/src/pages/ResultsPage.tsx
@@ -1,6 +1,7 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import {
   AlertTriangle,
+  Bot,
   ChevronLeft,
   ChevronRight,
   RefreshCw,
@@ -45,10 +46,7 @@ function sessionRefetchInterval(
   if (session.status === "running") {
     return 2000;
   }
-  if (
-    session.status === "ready" &&
-    (session.analysis_status === "pending" || session.analysis_status === "running")
-  ) {
+  if (session.status === "ready" && session.analysis_status === "running") {
     return 2000;
   }
   return false;
@@ -123,6 +121,14 @@ export function ResultsPage() {
     },
   });
 
+  const startAnalysisMutation = useMutation({
+    mutationFn: () => api.startSearchAnalysis(sessionId!),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ["search-session", sessionId] });
+      void queryClient.invalidateQueries({ queryKey: ["search-matches", sessionId] });
+    },
+  });
+
   const createBatchMutation = useMutation({
     mutationFn: () =>
       api.createApplyBatch({
@@ -170,9 +176,10 @@ export function ResultsPage() {
   const isBlocked = sessionQuery.data?.status === "blocked";
   const isRunning = sessionQuery.data?.status === "running";
   const analysisStatus = sessionQuery.data?.analysis_status;
+  const analysisPending =
+    sessionQuery.data?.status === "ready" && analysisStatus === "pending";
   const analysisInProgress =
-    sessionQuery.data?.status === "ready" &&
-    (analysisStatus === "pending" || analysisStatus === "running");
+    sessionQuery.data?.status === "ready" && analysisStatus === "running";
   const analysisFailed = sessionQuery.data?.status === "ready" && analysisStatus === "failed";
   const analysisReady = sessionQuery.data?.status === "ready" && analysisStatus === "ready";
 
@@ -191,7 +198,7 @@ export function ResultsPage() {
   );
   const allListingIds = useMemo(() => matches.map((match) => match.listing_id), [matches]);
 
-  const analysisProviderLabel = useMemo(() => {
+  const legacyAnalysisProviderLabel = useMemo(() => {
     if (analysisInProgress) {
       return "处理中";
     }
@@ -204,11 +211,44 @@ export function ResultsPage() {
     return "--";
   }, [analysisFailed, analysisInProgress, analysisReady, sessionQuery.data]);
 
-  const analysisHint = analysisInProgress
+  const legacyAnalysisHint = analysisInProgress
     ? "规则排序结果已经可看，模型分析完成后会自动刷新并重新排序。"
     : analysisFailed
       ? "模型分析未完成，当前仍显示规则排序结果。"
       : "模型分析完成后，这里会显示当前实际生效的分析来源。";
+
+  const analysisProviderLabel = useMemo(() => {
+    if (analysisPending) {
+      return "\u672a\u5f00\u59cb";
+    }
+    if (analysisInProgress) {
+      return "\u5206\u6790\u4e2d";
+    }
+    if (analysisFailed) {
+      return "\u5931\u8d25";
+    }
+    if (analysisReady && sessionQuery.data) {
+      return pillLabel(sessionQuery.data.analysis_provider);
+    }
+    return "--";
+  }, [
+    analysisFailed,
+    analysisInProgress,
+    analysisPending,
+    analysisReady,
+    sessionQuery.data,
+  ]);
+
+  const analysisHint = analysisPending
+    ? "\u7ed3\u679c\u5df2\u51c6\u5907\u597d\uff0c\u70b9\u51fb\u6309\u94ae\u540e\u624d\u4f1a\u5f00\u59cb AI \u5206\u6790\u548c\u91cd\u6392\u5e8f\u3002"
+    : analysisInProgress
+      ? "\u89c4\u5219\u6392\u5e8f\u7ed3\u679c\u5df2\u53ef\u67e5\u770b\uff0cAI \u5206\u6790\u5b8c\u6210\u540e\u4f1a\u81ea\u52a8\u5237\u65b0\u5e76\u91cd\u65b0\u6392\u5e8f\u3002"
+      : analysisFailed
+        ? "\u672c\u6b21 AI \u5206\u6790\u6ca1\u6709\u5b8c\u6210\uff0c\u5f53\u524d\u4ecd\u663e\u793a\u89c4\u5219\u6392\u5e8f\u7ed3\u679c\u3002"
+        : "\u5b8c\u6210 AI \u5206\u6790\u540e\uff0c\u8fd9\u91cc\u4f1a\u663e\u793a\u5f53\u524d\u751f\u6548\u7684\u5206\u6790\u6765\u6e90\u3002";
+
+  void legacyAnalysisProviderLabel;
+  void legacyAnalysisHint;
 
   const batchErrorMessage =
     createBatchMutation.isError && createBatchMutation.error instanceof Error
@@ -274,6 +314,33 @@ export function ResultsPage() {
         ) : null}
       </section>
 
+      {analysisPending ? (
+        <section className="rounded-[28px] border border-mint/30 bg-mint/10 p-5 shadow-console">
+          <div className="flex flex-wrap items-start justify-between gap-4">
+            <div className="max-w-3xl">
+              <p className="flex items-center gap-2 text-xs uppercase tracking-[0.24em] text-mint">
+                <Bot size={16} />
+                AI Analysis
+              </p>
+              <p className="mt-3 text-sm leading-6 text-ink">
+                {"\u89c4\u5219\u6392\u5e8f\u5df2\u5b8c\u6210\uff0c\u70b9\u51fb\u6309\u94ae\u540e\u624d\u4f1a\u5f00\u59cb\u5206\u6790\u5c97\u4f4d\uff0c\u5e76\u5728\u5b8c\u6210\u540e\u7528 AI \u7ed3\u679c\u91cd\u65b0\u6392\u5e8f\u3002"}
+              </p>
+            </div>
+            <button
+              type="button"
+              className="inline-flex items-center gap-2 rounded-full border border-ink/10 bg-ink px-4 py-2 text-sm font-semibold text-shell transition hover:bg-ink/90 disabled:cursor-not-allowed disabled:opacity-60"
+              onClick={() => startAnalysisMutation.mutate()}
+              disabled={startAnalysisMutation.isPending || !sessionId}
+            >
+              <Bot size={16} />
+              {startAnalysisMutation.isPending
+                ? "\u542f\u52a8\u4e2d..."
+                : "\u5f00\u59cb\u5206\u6790\u5c97\u4f4d"}
+            </button>
+          </div>
+        </section>
+      ) : null}
+
       {analysisInProgress ? (
         <section className="rounded-[28px] border border-signal/30 bg-signal/10 p-5 shadow-console">
           <p className="text-sm leading-6 text-ink">
@@ -285,9 +352,24 @@ export function ResultsPage() {
       {(analysisFailed ||
         (analysisReady && sessionQuery.data?.analysis_degraded && sessionQuery.data.analysis_notice)) ? (
         <section className="rounded-[28px] border border-amber-500/30 bg-amber-500/10 p-5 shadow-console">
-          <p className="text-sm leading-6 text-ink">
+          <div className="flex flex-wrap items-start justify-between gap-4">
+            <p className="max-w-3xl text-sm leading-6 text-ink">
             {sessionQuery.data?.analysis_notice || "模型分析未完成，当前展示的是规则排序结果。"}
-          </p>
+            </p>
+            {analysisFailed ? (
+              <button
+                type="button"
+                className="inline-flex items-center gap-2 rounded-full border border-ink/10 bg-shell px-4 py-2 text-sm font-semibold text-ink transition hover:bg-paper disabled:cursor-not-allowed disabled:opacity-60"
+                onClick={() => startAnalysisMutation.mutate()}
+                disabled={startAnalysisMutation.isPending || !sessionId}
+              >
+                <Bot size={16} />
+                {startAnalysisMutation.isPending
+                  ? "\u91cd\u8bd5\u4e2d..."
+                  : "\u91cd\u65b0\u5206\u6790\u5c97\u4f4d"}
+              </button>
+            ) : null}
+          </div>
         </section>
       ) : null}
 


### PR DESCRIPTION
## Summary
- fix OpenAI-compatible AI parsing and fallback behavior for runtime LLM analysis
- add a manual "start analysis" flow so job analysis only runs after the user clicks the button
- improve interactive Playwright window sizing so Tencent and similar login pages render fully

## Testing
- python -m pytest backend\tests\test_api.py
- npm run typecheck
- python -m pytest backend\tests\test_playwright_runtime.py backend\tests\test_official_account_pool.py
- python -m pytest backend\tests\test_llm.py backend\tests\test_api.py -k "runtime_llm or runtime_config or openai_failure or marks_ready_before_background_llm_finishes or incomplete_openai_config_falls_back_to_heuristic_in_search_pipeline"